### PR TITLE
support JSON response from API

### DIFF
--- a/ziti/edge/types.go
+++ b/ziti/edge/types.go
@@ -93,6 +93,7 @@ func ApiResponseDecode(data interface{}, resp io.Reader) (*ApiResponseMetadata, 
 	apiR := &apiResponse{
 		Data: data,
 	}
+
 	if err := json.NewDecoder(resp).Decode(apiR); err != nil {
 		return nil, err
 	}

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -568,7 +568,7 @@ func (context *contextImpl) createSession(id string, bind bool) (*edge.Session, 
 	pfxlog.Logger().Debugf("requesting session from %v", fullSessionUrl)
 	req, _ := http.NewRequest("POST", fullSessionUrl, reqBody)
 	req.Header.Set(constants.ZitiSession, context.apiSession.Token)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("content-type", "application/json")
 
 	logrus.WithField("service_id", id).Debug("requesting session")
 	resp, err := context.clt.Do(req)
@@ -589,7 +589,7 @@ func (context *contextImpl) refreshSession(id string) (*edge.Session, error) {
 	pfxlog.Logger().Debugf("requesting session from %v", sessionLookupUrlStr)
 	req, _ := http.NewRequest(http.MethodGet, sessionLookupUrlStr, nil)
 	req.Header.Set(constants.ZitiSession, context.apiSession.Token)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("content-type", "application/json")
 
 	logrus.WithField("sessionId", id).Debug("requesting session")
 	resp, err := context.clt.Do(req)


### PR DESCRIPTION
For Open API 2.0 - it is easier to support an enrollment endpoint that returns JSON for all enrollment methods (Open API 2.0 limitations). Support for `text/plain` response is still present and backward compatible if the client does not specify the content types it will accept or specifies `text/plain` or `application/x-pem-file`. 

Meaning: existing code that doesn't request JSON, won't get JSON. Code that requests JSON gets JSON.

Clients that use the specification (swagger.yml) will request JSON and get JSON. Old SDKs will not limit accepted types and will get PEM content.

This code change makes it so that the GO SDK will work no matter what the server returns.


