### PR TITLE
update enroller to handle when there's multiple content-types if that…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openziti/sdk-golang
 
 go 1.14
 
-// replace github.com/netfoundry/ziti-foundation => ../ziti-foundation
+// replace github.com/openziti/foundation => ../foundation
 
 require (
 	github.com/Jeffail/gabs v1.4.0


### PR DESCRIPTION
… ever happens

first of two pr's for enroller. this addresses the issue in the enroller.go the added code below is mostly due to an indent so it's mostly the same as before.

Enroller output example after this patch:
![image](https://user-images.githubusercontent.com/46322585/84801775-99b2a680-afcd-11ea-8b25-cb2ae63fc79e.png)
