### PR TITLE
Add support for AppData

### DIFF
--- a/example/call/call.go
+++ b/example/call/call.go
@@ -119,7 +119,7 @@ func (event *userInputEvent) handle(app *callApp) {
 		dialOptions := &ziti.DialOptions{
 			Identity:       identity,
 			ConnectTimeout: 1 * time.Minute,
-			AppData: []byte("hi there"),
+			AppData:        []byte("hi there"),
 		}
 		conn, err := app.context.DialWithOptions(app.service, dialOptions)
 		if err != nil {

--- a/example/call/call.go
+++ b/example/call/call.go
@@ -53,7 +53,12 @@ func (event *connectEvent) handle(app *callApp) {
 		fmt.Printf("New incoming connection, dropping existing unanswered connection request\n")
 		_ = app.pending.Close()
 	}
-	fmt.Printf("Incoming connection from %v. Type /accept to accept the connection\n> ", event.conn.RemoteAddr().String())
+	connInfo := "from " + event.conn.RemoteAddr().String()
+	if edgeConn, ok := event.conn.(edge.Conn); ok {
+		appData := edgeConn.GetAppData()
+		connInfo += " with appData '" + string(appData) + "'"
+	}
+	fmt.Printf("Incoming connection %v. Type /accept to accept the connection\n> ", connInfo)
 	app.pending = event.conn
 }
 
@@ -114,6 +119,7 @@ func (event *userInputEvent) handle(app *callApp) {
 		dialOptions := &ziti.DialOptions{
 			Identity:       identity,
 			ConnectTimeout: 1 * time.Minute,
+			AppData: []byte("hi there"),
 		}
 		conn, err := app.context.DialWithOptions(app.service, dialOptions)
 		if err != nil {

--- a/ziti/edge/conn.go
+++ b/ziti/edge/conn.go
@@ -80,6 +80,7 @@ type ServiceConn interface {
 	net.Conn
 	CloseWriter
 	IsClosed() bool
+	GetAppData() []byte
 }
 
 type Conn interface {
@@ -199,6 +200,7 @@ type DialOptions struct {
 	ConnectTimeout time.Duration
 	Identity       string
 	CallerId       string
+	AppData        []byte
 }
 
 func (d DialOptions) GetConnectTimeout() time.Duration {

--- a/ziti/edge/impl/conn.go
+++ b/ziti/edge/impl/conn.go
@@ -60,6 +60,7 @@ type edgeConn struct {
 	rxKey    []byte
 	receiver secretstream.Decryptor
 	sender   secretstream.Encryptor
+	appData  []byte
 }
 
 func (conn *edgeConn) Write(data []byte) (int, error) {
@@ -490,6 +491,7 @@ func (conn *edgeConn) newChildConnection(event *edge.MsgEvent) {
 		msgMux:         conn.msgMux,
 		sourceIdentity: sourceIdentity,
 		crypto:         conn.crypto,
+		appData:        message.Headers[edge.AppDataHeader],
 	}
 
 	_ = conn.msgMux.AddMsgSink(edgeCh) // duplicate errors only happen on the server side, since client controls ids
@@ -549,6 +551,10 @@ func (conn *edgeConn) newChildConnection(event *edge.MsgEvent) {
 	} else {
 		logger.Errorf("failed to receive start after dial. got %v", startMsg)
 	}
+}
+
+func (conn *edgeConn) GetAppData() []byte {
+	return conn.appData
 }
 
 type closeConnEvent struct {

--- a/ziti/edge/messages.go
+++ b/ziti/edge/messages.go
@@ -173,6 +173,9 @@ func NewConnectMsg(connId uint32, token string, pubKey []byte, options *DialOpti
 	if options.CallerId != "" {
 		msg.Headers[CallerIdHeader] = []byte(options.CallerId)
 	}
+	if options.AppData != nil {
+		msg.Headers[AppDataHeader] = options.AppData
+	}
 	return msg
 }
 

--- a/ziti/edge/messages.go
+++ b/ziti/edge/messages.go
@@ -49,6 +49,7 @@ const (
 	CallerIdHeader                 = 1008
 	CryptoMethodHeader             = 1009
 	FlagsHeader                    = 1010
+	AppDataHeader                  = 1011
 
 	PrecedenceDefault  Precedence = 0
 	PrecedenceRequired            = 1

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -68,6 +68,7 @@ type Context interface {
 type DialOptions struct {
 	ConnectTimeout time.Duration
 	Identity       string
+	AppData        []byte
 }
 
 func (d DialOptions) GetConnectTimeout() time.Duration {
@@ -364,6 +365,7 @@ func (context *contextImpl) DialWithOptions(serviceName string, options *DialOpt
 	edgeDialOptions := &edge.DialOptions{
 		ConnectTimeout: options.ConnectTimeout,
 		Identity:       options.Identity,
+		AppData:        options.AppData,
 	}
 	if edgeDialOptions.GetConnectTimeout() == 0 {
 		edgeDialOptions.ConnectTimeout = 15 * time.Second


### PR DESCRIPTION
- Adds AppDataHeader to the edge protocol.
- Adds AppData to dial options. The accepting side of the connection gets the app data by type-asserting the accepted conn to edge.Conn.

      conn, err := listener.Accept()
      if edgeConn, ok := conn.(edge.Conn); ok {
          appData := edgeConn.GetAppData()
      }

  I'm open to alternatives though.