### PR TITLE
Move laziness into ctrl client, handle reauthenticating when dialing

### DIFF
--- a/ziti/edge/api/client.go
+++ b/ziti/edge/api/client.go
@@ -53,6 +53,7 @@ func (e NotFound) Error() string {
 type Client interface {
 	Initialize() error
 	GetIdentity() identity.Identity
+	GetCurrentApiSession() *edge.ApiSession
 	Login(info map[string]interface{}, configTypes []string) (*edge.ApiSession, error)
 	Refresh() (*time.Time, error)
 	GetServices() ([]*edge.Service, error)
@@ -83,6 +84,10 @@ type ctrlClient struct {
 	zitiUrl    *url.URL
 	clt        http.Client
 	apiSession *edge.ApiSession
+}
+
+func (c *ctrlClient) GetCurrentApiSession() *edge.ApiSession {
+	return c.apiSession
 }
 
 func (c *ctrlClient) CreateSession(svcId string, kind edge.SessionType) (*edge.Session, error) {

--- a/ziti/edge/api/client.go
+++ b/ziti/edge/api/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/common/constants"
+	"github.com/openziti/foundation/identity/identity"
 	"github.com/openziti/sdk-golang/ziti/edge"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -50,6 +51,8 @@ func (e NotFound) Error() string {
 }
 
 type Client interface {
+	Initialize() error
+	GetIdentity() identity.Identity
 	Login(info map[string]interface{}, configTypes []string) (*edge.ApiSession, error)
 	Refresh() (*time.Time, error)
 	GetServices() ([]*edge.Service, error)
@@ -58,7 +61,7 @@ type Client interface {
 	SendPostureResponse(response PostureResponse) error
 }
 
-func NewClient(ctrl *url.URL, tlsCfg *tls.Config) (Client, error) {
+func NewClient(ctrl *url.URL, tlsCfg *tls.Config) (*ctrlClient, error) {
 	return &ctrlClient{
 		zitiUrl: ctrl,
 		clt: http.Client{

--- a/ziti/edge/api/lazy_client.go
+++ b/ziti/edge/api/lazy_client.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"github.com/openziti/foundation/identity/identity"
+	"github.com/openziti/sdk-golang/ziti/config"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"net/url"
+	"os"
+	"sync"
+)
+
+func NewLazyClient(config *config.Config, initCallback func(Client) error) Client {
+	return &lazyClient{
+		config:       config,
+		initComplete: initCallback,
+	}
+}
+
+type lazyClient struct {
+	*ctrlClient
+	config       *config.Config
+	initDone     sync.Once
+	initComplete func(Client) error
+	id           identity.Identity
+}
+
+func (client *lazyClient) GetIdentity() identity.Identity {
+	return client.id
+}
+
+func (client *lazyClient) ensureConfigPresent() error {
+	if client.config != nil {
+		return nil
+	}
+
+	const configEnvVarName = "ZITI_SDK_CONFIG"
+	// If configEnvVarName is set, try to use it.
+	// The calling application may override this by calling NewContextWithConfig
+	confFile := os.Getenv(configEnvVarName)
+
+	if confFile == "" {
+		return errors.Errorf("unable to configure ziti as config environment variable %v not populated", configEnvVarName)
+	}
+
+	logrus.Infof("loading Ziti configuration from %s", confFile)
+	cfg, err := config.NewFromFile(confFile)
+	if err != nil {
+		return errors.Errorf("error loading config file specified by ${%s}: %v", configEnvVarName, err)
+	}
+	client.config = cfg
+	return nil
+}
+
+func (client *lazyClient) Initialize() error {
+	var err error
+	client.initDone.Do(func() {
+		err = client.load()
+	})
+	return err
+}
+
+func (client *lazyClient) load() error {
+	err := client.ensureConfigPresent()
+	if err != nil {
+		return err
+	}
+	zitiUrl, _ := url.Parse(client.config.ZtAPI)
+
+	client.id, err = identity.LoadIdentity(client.config.ID)
+	if err != nil {
+		return err
+	}
+	client.ctrlClient, err = NewClient(zitiUrl, client.id.ClientTLSConfig())
+	if err != nil {
+		return err
+	}
+	return client.initComplete(client)
+}

--- a/ziti/ziti_test.go
+++ b/ziti/ziti_test.go
@@ -19,11 +19,9 @@ func Test_contextImpl_processServiceUpdates(t *testing.T) {
 	}
 
 	ctx := &contextImpl{
-		config: nil,
 		options: &config.Options{
 			OnServiceUpdate: servUpdate,
 		},
-		initDone:     sync.Once{},
 		services:     sync.Map{},
 		sessions:     sync.Map{},
 		postureCache: posture.NewCache(nil),

--- a/ziti/ziti_test.go
+++ b/ziti/ziti_test.go
@@ -27,7 +27,7 @@ func Test_contextImpl_processServiceUpdates(t *testing.T) {
 		postureCache: posture.NewCache(nil),
 	}
 
-	services := []*edge.Service{}
+	var services []*edge.Service
 
 	for i := 0; i < 5; i++ {
 		services = append(services, &edge.Service{


### PR DESCRIPTION
Moves logic specific to web api clients in preparation for a second implementation which uses the control channel.
Adds logic to handle creating a new api session on dial, if the current session has expired (say after waking a laptop from sleep) 