### PR TITLE
normalize file paths for posture checks 

### DIFF
--- a/ziti/edge/posture/posture_windows_test.go
+++ b/ziti/edge/posture/posture_windows_test.go
@@ -1,0 +1,35 @@
+// +build windows
+
+package posture
+
+import (
+	"testing"
+)
+
+func TestRunningProcess(t *testing.T) {
+	p := Process("C:\\Windows\\System32\\svchost.exe")
+	if !p.IsRunning {
+		t.Fail()
+	}
+}
+
+func TestRunningProcessCaseInsensitive(t *testing.T) {
+	p := Process("C:\\windows\\system32\\SVCHOST.EXE")
+	if !p.IsRunning {
+		t.Fail()
+	}
+}
+
+func TestSlashNormalizationForwardSlash(t *testing.T) {
+	p := Process("C:/windows/system32/SVCHOST.EXE")
+	if !p.IsRunning {
+		t.Fail()
+	}
+}
+
+func TestSlashNormalizationExtraSlashes(t *testing.T) {
+	p := Process("C:/windows///system32////SVCHOST.EXE")
+	if !p.IsRunning {
+		t.Fail()
+	}
+}

--- a/ziti/edge/posture/posture_windows_test.go
+++ b/ziti/edge/posture/posture_windows_test.go
@@ -1,5 +1,20 @@
 // +build windows
 
+/*
+	Copyright 2019 NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
 package posture
 
 import (


### PR DESCRIPTION
This will allow case insensitive matching in windows and it will also allow for extra slashes to be fatfingered and still match