### PR TITLE
Add more context to edge conn local/remote addresses

### DIFF
--- a/ziti/edge/addr.go
+++ b/ziti/edge/addr.go
@@ -29,5 +29,5 @@ func (e *Addr) Network() string {
 }
 
 func (e *Addr) String() string {
-	return fmt.Sprintf(":%v", e.MsgCh.Id())
+	return fmt.Sprintf("ziti-edge-router connId=%v, logical=%v", e.MsgCh.Id(), e.MsgCh.LogicalName())
 }

--- a/ziti/edge/impl/conn.go
+++ b/ziti/edge/impl/conn.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"io"
 	"net"
@@ -140,15 +141,15 @@ func (conn *edgeConn) Network() string {
 }
 
 func (conn *edgeConn) String() string {
-	return conn.sourceIdentity
+	return fmt.Sprintf("zitiConn connId=%v svcId=%v sourceIdentity=%v", conn.Id(), conn.serviceId, conn.sourceIdentity)
 }
 
 func (conn *edgeConn) LocalAddr() net.Addr {
-	return &edge.Addr{MsgCh: conn.MsgChannel}
+	return conn
 }
 
 func (conn *edgeConn) RemoteAddr() net.Addr {
-	return conn
+	return &edge.Addr{MsgCh: conn.MsgChannel}
 }
 
 func (conn *edgeConn) SetDeadline(t time.Time) error {

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -713,7 +713,7 @@ func (context *contextImpl) connectEdgeRouter(routerName, ingressUrl string, ret
 	})
 
 	start := time.Now().UnixNano()
-	ch, err := channel2.NewChannel("ziti-sdk", dialer, nil)
+	ch, err := channel2.NewChannel(fmt.Sprintf("ziti-sdk[router=%v]", ingressUrl), dialer, nil)
 	if err != nil {
 		logger.Error(err)
 		retF(&edgeRouterConnResult{routerUrl: ingressUrl, err: err})


### PR DESCRIPTION
Output will now look like (service name and IPs anonymized):

```
 INFO edge/tunnel.Run: {dst-local=[zitiConn connId=3 svcId=example.service.name sourceIdentity=] dst-remote=[ziti-edge-router connId=3, logical=ziti-sdk[router=tls://127.0.0.1:443]] src-remote=[127.0.0.1:42294] src-local=[127.0.01:80]} tunnel started
```