### PR TITLE
fix edge connection closing race condition

### DIFF
--- a/ziti/edge/conn.go
+++ b/ziti/edge/conn.go
@@ -171,7 +171,7 @@ func (ec *MsgChannel) WriteTraced(data []byte, msgUUID []byte, hdrs map[int32][]
 func (ec *MsgChannel) SendState(msg *channel2.Message) error {
 	msg.PutUint32Header(SeqHeader, ec.msgIdSeq.Next())
 	ec.TraceMsg("SendState", msg)
-	syncC, err := ec.SendAndSyncWithPriority(msg, channel2.Highest)
+	syncC, err := ec.SendAndSyncWithPriority(msg, channel2.Standard)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix a problem when ConnectionClosedMessage gets ahead of last piece(s) of data in the following scenario
this is more likely to happen under heavier loads
```
conn.Write("this")
conn.Write("that")
conn.Write("and the other")
conn.Close() // ContentTypeStateClosed message may get ahead of previous writes
```