### PR TITLE
Upgrading to go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openziti/sdk-golang
 
-go 1.17
+go 1.18
 
 //replace github.com/openziti/foundation => ../foundation
 


### PR DESCRIPTION
Fabric has been updated to 1.18.  The SDK also needs an update for it to compile.

Without the update:
```
go build ./...
# github.com/openziti/foundation/util/concurrenz
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/atomic_value.go:21:20: syntax error: unexpected any, expecting ]
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/atomic_value.go:23:24: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/atomic_value.go:27:24: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/atomic_value.go:29:2: syntax error: non-declaration statement outside function body
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:21:23: syntax error: unexpected comparable, expecting ]
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:26:27: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:31:2: syntax error: non-declaration statement outside function body
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:39:27: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:43:27: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:47:27: syntax error: unexpected [, expecting comma or )
../../../.local/ziti/pkg/mod/github.com/openziti/foundation@v0.17.23/util/concurrenz/copy_on_write_map.go:47:27: too many errors
note: module requires Go 1.18
```