### PR TITLE
use full edge client API urls

### DIFF
--- a/ziti/config/token.go
+++ b/ziti/config/token.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/url"
-	"path"
 	"reflect"
 
 	"github.com/golang-jwt/jwt"
@@ -28,6 +27,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
+
+var EnrollUrl, _ = url.Parse("/edge/client/v1/enroll")
 
 type Versions struct {
 	Api           string `json:"api"`
@@ -53,7 +54,8 @@ func (t *EnrollmentClaims) EnrolmentUrl() string {
 		pfxlog.Logger().WithError(err).WithField("url", t.Issuer).Panic("could not parse issuer as URL")
 	}
 
-	enrollmentUrl.Path = path.Join(enrollmentUrl.Path, "enroll")
+	enrollmentUrl = enrollmentUrl.ResolveReference(EnrollUrl)
+
 	query := enrollmentUrl.Query()
 	query.Add("method", t.EnrollmentMethod)
 	query.Add("token", t.Id)

--- a/ziti/enroll/enroll.go
+++ b/ziti/enroll/enroll.go
@@ -29,11 +29,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/openziti/sdk-golang/ziti/edge/api"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -548,7 +548,7 @@ func FetchCertificates(urlRoot string, rootCaPool *x509.CertPool) []*x509.Certif
 		pfxlog.Logger().WithError(err).WithField("url", urlRoot).Panic("could not parse base url to retrieve CA store")
 	}
 
-	certStoreUrl.Path = path.Join(certStoreUrl.Path, ".well-known/est/cacerts") //specified by rfc7030
+	certStoreUrl = certStoreUrl.ResolveReference(api.WellKnownCaStoreUrl)
 
 	resp, respErr := client.Get(certStoreUrl.String())
 


### PR DESCRIPTION
While working on xweb changes, I removed the default legacy API handler and noticed the SDK was still using the legacy API path.