### PR TITLE
Fix spelling issues reported by codespell

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,6 +12,6 @@ and to the violator.
 
 ## Violations
 
-Contributors violating the Code of Conduct will receive public notification of the violation. Contined violations or
-aggregious violations of the Code of Conduct will result in the contributor being removed from the contributors list as
+Contributors violating the Code of Conduct will receive public notification of the violation. Continued violations or
+egregious violations of the Code of Conduct will result in the contributor being removed from the contributors list as
 well as further contributions being declined.

--- a/example/zping/README.md
+++ b/example/zping/README.md
@@ -2,7 +2,7 @@
 
 What is zping?  zping replaces the function of icmp ping tool in a ziti network.
 
-It provides an end to end latency measurment between any two ziti identities in a ziti network and like icmp ping will provide the following metrics upon completion of the ping session:
+It provides an end to end latency measurement between any two ziti identities in a ziti network and like icmp ping will provide the following metrics upon completion of the ping session:
 
 min, max and mean latency and standard deviation.
 
@@ -54,7 +54,7 @@ Linux:
 
 3. Create a simple sdk service named “ziti-ping” this is the default service zping looks for but can be          
 
-   overriden  with the -s command line flag.
+   overridden  with the -s command line flag.
 
 4. Create a bind policy with identityRoles set to [#ping] and serviceroles set to [@ziti-ping].
 
@@ -118,6 +118,6 @@ Linux:
         100 bytes from zpingendpoint1: ziti_seq=5 time=76.849ms
         
         --- zpingendpoint1 ping statistics ---
-        5 packets transmitted and 5 packets recieved, 0.00% packet loss
+        5 packets transmitted and 5 packets received, 0.00% packet loss
         round-trip min/max/avg/stddev 75.597/76.849/76.309/0.417 ms
 ```

--- a/example/zping/cmd/client.go
+++ b/example/zping/cmd/client.go
@@ -1,26 +1,22 @@
 /*
-	Copyright 2019 NetFoundry Inc.
+Copyright 2019 NetFoundry Inc.
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package cmd
 
 import (
 	"fmt"
-	"github.com/openziti/sdk-golang/ziti"
-	"github.com/openziti/sdk-golang/ziti/config"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"html"
 	"math"
 	"math/rand"
@@ -30,6 +26,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func RandomPingData(n int) string {
@@ -82,7 +83,7 @@ func (psession *ping_session) getMinMaxAvg() {
 
 func (psession *ping_session) finish() {
 	fmt.Printf("\n--- %+v ping statistics ---", psession.identity)
-	fmt.Printf("\n%+v packets transmitted and %+v packets recieved, %.2f%+v packet loss\n", psession.psent, psession.prec, (1.0-(float32(psession.prec)/float32(psession.psent)))*100.00, html.EscapeString("%"))
+	fmt.Printf("\n%+v packets transmitted and %+v packets received, %.2f%+v packet loss\n", psession.psent, psession.prec, (1.0-(float32(psession.prec)/float32(psession.psent)))*100.00, html.EscapeString("%"))
 	psession.getMinMaxAvg()
 	psession.getStddev()
 	fmt.Printf("round-trip min/max/avg/stddev %.3f/%.3f/%.3f/%.3f ms\n", psession.minrt, psession.maxrt, psession.avgrt, psession.stddv)

--- a/example/zping/cmd/root.go
+++ b/example/zping/cmd/root.go
@@ -1,24 +1,25 @@
 /*
-	Copyright 2019 NetFoundry Inc.
+Copyright 2019 NetFoundry Inc.
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ var rootCmd = &cobra.Command{
 	Use:   "zping",
 	Short: "Latency Diagnostic tool for ziti",
 	Long: `zping replaces the function of icmp ping tool in a ziti network.
-It provides an end to end latency measurment between any two ziti identities in
+It provides an end to end latency measurement between any two ziti identities in
 a ziti network and like icmp ping will provide the following metrics upon completion
 of the ping session: min, max and mean latency and standard deviation as well as % loss.
 zping uses the addressable terminator function of ziti to direct ping requests to

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,5 +1,5 @@
-# Excercises
+# Exercises
 
 This directory is meant for any code samples or documentation that would help one learn more about how to use the Ziti SDK for go.
 
-The first exercise shows code before and after zitifying a simple http server. 
+The first exercise shows code before and after zitifying a simple http server.

--- a/http_transport.go
+++ b/http_transport.go
@@ -3,12 +3,13 @@ package sdk_golang
 import (
 	"context"
 	"crypto/tls"
-	"github.com/openziti/sdk-golang/ziti"
-	"github.com/openziti/sdk-golang/ziti/edge"
-	cmap "github.com/orcaman/concurrent-map/v2"
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/edge"
+	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
 // NewHttpClient returns a http.Client that can be used exactly as any other http.Client but will route requests
@@ -45,7 +46,7 @@ func NewZitiTransport(ctx ziti.Context, clientTlsConfig *tls.Config) *ZitiTransp
 	return zitiTransport
 }
 
-// urlToServiceName removes ports from host names that internal standard GoLang capabilies may have added.
+// urlToServiceName removes ports from host names that internal standard GoLang capabilities may have added.
 func urlToServiceName(addr string) string {
 	return strings.Split(addr, ":")[0]
 }

--- a/ziti/edge/api/client.go
+++ b/ziti/edge/api/client.go
@@ -5,6 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/identity"
 	"github.com/openziti/sdk-golang/ziti/constants"
@@ -12,11 +18,6 @@ import (
 	"github.com/openziti/sdk-golang/ziti/sdkinfo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
-	"time"
 )
 
 type AuthFailure struct {
@@ -161,7 +162,7 @@ func (c *ctrlClient) GetCurrentIdentity() (*edge.CurrentIdentity, error) {
 	}
 
 	if resp == nil {
-		return nil, errors.New("controller returned empty respose")
+		return nil, errors.New("controller returned empty response")
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -198,7 +199,7 @@ func (c *ctrlClient) IsServiceListUpdateAvailable() (bool, error) {
 	}
 
 	if resp == nil {
-		return false, errors.New("controller returned empty respose")
+		return false, errors.New("controller returned empty response")
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -281,9 +282,9 @@ func (c *ctrlClient) SendPostureResponseBulk(responses []*PostureResponse) error
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("recieved error during bulk posture response submission, could not read body: %v", err)
+			return fmt.Errorf("received error during bulk posture response submission, could not read body: %v", err)
 		}
-		return fmt.Errorf("recieved error during bulk posture response submission: %v", string(body))
+		return fmt.Errorf("received error during bulk posture response submission: %v", string(body))
 	}
 
 	return nil
@@ -311,9 +312,9 @@ func (c *ctrlClient) SendPostureResponse(response PostureResponse) error {
 	if resp.StatusCode != http.StatusCreated {
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("recieved error during posture response submission, could not read body: %v", err)
+			return fmt.Errorf("received error during posture response submission, could not read body: %v", err)
 		}
-		return fmt.Errorf("recieved error during posture response submission: %v", string(body))
+		return fmt.Errorf("received error during posture response submission: %v", string(body))
 	}
 
 	return nil
@@ -514,7 +515,7 @@ func (c *ctrlClient) EnrollMfa() (*MfaEnrollment, error) {
 }
 
 // Remove the previous enrolled MFA. A valid TOTP/recovery code is required. If MFA enrollment has not been completed
-// an emty string can be used to remove the partially started MFA enrollment.
+// an empty string can be used to remove the partially started MFA enrollment.
 func (c *ctrlClient) RemoveMfa(code string) error {
 	body := NewMFACodeBody(code)
 	reqBody := bytes.NewBuffer(body)

--- a/ziti/edge/impl/conn.go
+++ b/ziti/edge/impl/conn.go
@@ -18,13 +18,14 @@ package impl
 
 import (
 	"fmt"
-	"github.com/openziti/foundation/v2/info"
-	"github.com/sirupsen/logrus"
 	"io"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/openziti/foundation/v2/info"
+	"github.com/sirupsen/logrus"
 
 	"github.com/michaelquigley/pfxlog"
 	"github.com/netfoundry/secretstream"
@@ -381,7 +382,7 @@ func (conn *edgeConn) Read(p []byte) (int, error) {
 			conn.closed.Store(true)
 			return 0, io.EOF
 		} else if err != nil {
-			log.Debugf("unexepcted sequencer err (%v)", err)
+			log.Debugf("unexpected sequencer err (%v)", err)
 			return 0, err
 		}
 

--- a/ziti/edge/messages.go
+++ b/ziti/edge/messages.go
@@ -18,6 +18,7 @@ package edge
 
 import (
 	"encoding/binary"
+
 	"github.com/openziti/channel/v2"
 	"github.com/openziti/foundation/v2/uuidz"
 	"github.com/pkg/errors"
@@ -314,7 +315,7 @@ func UnmarshalDialResult(msg *channel.Message) (*DialResult, error) {
 
 	if msg.ContentType == ContentTypeDialSuccess {
 		if len(msg.Body) != 4 {
-			return nil, errors.Errorf("dial success msg improperly formated. body len: %v", len(msg.Body))
+			return nil, errors.Errorf("dial success msg improperly formatted. body len: %v", len(msg.Body))
 		}
 		newConnId := binary.LittleEndian.Uint32(msg.Body)
 		return &DialResult{

--- a/ziti/edge/types.go
+++ b/ziti/edge/types.go
@@ -19,14 +19,15 @@ package edge
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/michaelquigley/pfxlog"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 	"io"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/michaelquigley/pfxlog"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -283,7 +284,7 @@ func (self *ZitiAddress) UnmarshalText(data []byte) error {
 		return nil
 	}
 
-	// minimun valid hostname is `a.b`
+	// minimum valid hostname is `a.b`
 	// minimum valid domain name is '*.c'
 	if len(v) < 3 {
 		return errors.New("invalid address")

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -20,6 +20,14 @@ import (
 	"encoding/json"
 	errors2 "errors"
 	"fmt"
+	"math"
+	"net"
+	"reflect"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel/v2"
@@ -38,13 +46,6 @@ import (
 	"github.com/pkg/errors"
 	metrics2 "github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
-	"math"
-	"net"
-	"reflect"
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -218,7 +219,7 @@ func (context *contextImpl) initialize() error {
 }
 
 func (context *contextImpl) processServiceUpdates(services []*edge.Service) {
-	pfxlog.Logger().Debugf("procesing service updates with %v services", len(services))
+	pfxlog.Logger().Debugf("processing service updates with %v services", len(services))
 
 	idMap := make(map[string]*edge.Service)
 	for _, s := range services {


### PR DESCRIPTION
Hi,

This fix all spelling issues reported by [codespell](https://github.com/codespell-project/codespell). 
If you agree, I can add this tool to GH Actions in another PR.
**NOTE**: My *VIM* runs *go-fmt* automatically, so if you don't like it, I can remove those unrelated changes.

Should fix #309.

See,
```bash
$ codespell -L keypair
./CODE_OF_CONDUCT.md:15: Contined ==> Continued
./CODE_OF_CONDUCT.md:16: aggregious ==> egregious
./http_transport.go:48: capabilies ==> capabilities
./example/zping/README.md:5: measurment ==> measurement
./example/zping/README.md:57: overriden ==> overridden
./example/zping/README.md:121: recieved ==> received
./example/zping/cmd/client.go:85: recieved ==> received
./example/zping/cmd/root.go:33: measurment ==> measurement
./ziti/ziti.go:221: procesing ==> processing
./ziti/edge/types.go:286: minimun ==> minimum
./ziti/edge/messages.go:317: formated ==> formatted
./ziti/edge/impl/conn.go:384: unexepcted ==> unexpected
./ziti/edge/api/client.go:164: respose ==> response
./ziti/edge/api/client.go:201: respose ==> response
./ziti/edge/api/client.go:284: recieved ==> received
./ziti/edge/api/client.go:286: recieved ==> received
./ziti/edge/api/client.go:314: recieved ==> received
./ziti/edge/api/client.go:316: recieved ==> received
./ziti/edge/api/client.go:517: emty ==> empty
./exercises/README.md:1: Excercises ==> Exercises
```