### PR TITLE
plumbs config types from config to authentication requests

### DIFF
--- a/edge-apis/authwrapper.go
+++ b/edge-apis/authwrapper.go
@@ -15,19 +15,20 @@ import (
 // limitation dealing with accessing field of generically typed fields.
 type AuthEnabledApi interface {
 	//Authenticate will attempt to issue an authentication request using the provided credentials and http client.
-	//These function acts as abstraction around the underlying go-swagger generated client and will use the default
+	//These functions act as abstraction around the underlying go-swagger generated client and will use the default
 	//http client if not provided.
-	Authenticate(credentials Credentials, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error)
+	Authenticate(credentials Credentials, configTypes []string, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error)
 }
 
 // ZitiEdgeManagement is an alias of the go-swagger generated client that allows this package to add additional
 // functionality to the alias type to implement the AuthEnabledApi interface.
 type ZitiEdgeManagement rest_management_api_client.ZitiEdgeManagement
 
-func (self ZitiEdgeManagement) Authenticate(credentials Credentials, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error) {
+func (self ZitiEdgeManagement) Authenticate(credentials Credentials, configTypes []string, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error) {
 	params := managementAuthentication.NewAuthenticateParams()
 	params.Auth = credentials.Payload()
 	params.Method = credentials.Method()
+	params.Auth.ConfigTypes = append(params.Auth.ConfigTypes, configTypes...)
 
 	resp, err := self.Authentication.Authenticate(params, getClientAuthInfoOp(credentials, httpClient))
 
@@ -42,10 +43,11 @@ func (self ZitiEdgeManagement) Authenticate(credentials Credentials, httpClient 
 // functionality to the alias type to implement the AuthEnabledApi interface.
 type ZitiEdgeClient rest_client_api_client.ZitiEdgeClient
 
-func (self ZitiEdgeClient) Authenticate(credentials Credentials, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error) {
+func (self ZitiEdgeClient) Authenticate(credentials Credentials, configTypes []string, httpClient *http.Client) (*rest_model.CurrentAPISessionDetail, error) {
 	params := clientAuthentication.NewAuthenticateParams()
 	params.Auth = credentials.Payload()
 	params.Method = credentials.Method()
+	params.Auth.ConfigTypes = append(params.Auth.ConfigTypes, configTypes...)
 
 	resp, err := self.Authentication.Authenticate(params, getClientAuthInfoOp(credentials, httpClient))
 

--- a/edge-apis/clients.go
+++ b/edge-apis/clients.go
@@ -37,7 +37,7 @@ func (self *BaseClient[A]) GetCurrentApiSession() *rest_model.CurrentAPISessionD
 // the API Session details will be returned and the current client will make authenticated requests on future
 // calls. On an error the API Session in use will be cleared and subsequent requests will become/continue to be
 // made in an unauthenticated fashion.
-func (self *BaseClient[A]) Authenticate(credentials Credentials) (*rest_model.CurrentAPISessionDetail, error) {
+func (self *BaseClient[A]) Authenticate(credentials Credentials, configTypes []string) (*rest_model.CurrentAPISessionDetail, error) {
 	//casting to `any` works around golang error that happens when type asserting a generic typed field
 	myAny := any(self.API)
 	if a, ok := myAny.(AuthEnabledApi); ok {
@@ -50,7 +50,7 @@ func (self *BaseClient[A]) Authenticate(credentials Credentials) (*rest_model.Cu
 			self.HttpTransport.TLSClientConfig.RootCAs = self.Components.CaPool
 		}
 
-		apiSession, err := a.Authenticate(credentials, self.HttpClient)
+		apiSession, err := a.Authenticate(credentials, configTypes, self.HttpClient)
 
 		if err != nil {
 			return nil, err

--- a/ziti/client.go
+++ b/ziti/client.go
@@ -41,6 +41,7 @@ type CtrlClient struct {
 	ApiSessionCertInstance      string
 
 	PostureCache *posture.Cache
+	ConfigTypes  []string
 }
 
 // GetCurrentApiSession returns the current cached ApiSession or nil
@@ -82,7 +83,7 @@ func (self *CtrlClient) Authenticate() (*rest_model.CurrentAPISessionDetail, err
 
 	self.ApiSessionCertificate = nil
 
-	apiSession, err := self.ClientApiClient.Authenticate(self.Credentials)
+	apiSession, err := self.ClientApiClient.Authenticate(self.Credentials, self.ConfigTypes)
 
 	if err != nil {
 		return nil, err

--- a/ziti/contexts.go
+++ b/ziti/contexts.go
@@ -141,6 +141,7 @@ func NewContextWithOpts(cfg *Config, options *Options) (Context, error) {
 	newContext.CtrlClt = &CtrlClient{
 		ClientApiClient: edge_apis.NewClientApiClient(apiUrl, cfg.Credentials.GetCaPool()),
 		Credentials:     cfg.Credentials,
+		ConfigTypes:     cfg.ConfigTypes,
 	}
 
 	newContext.CtrlClt.PostureCache = posture.NewCache(newContext.CtrlClt, newContext.closeNotify)


### PR DESCRIPTION
Authentication requests were only using the credential config types and ignoring ziti.Config.ConfigTypes.