### PR TITLE
adds events to go sdk, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,221 @@
+# Release 0.20.48
+
+## What's New
+
+* Change log - This change log was added and is a reelection of all changes from `v0.20.0` to `v0.20.23`
+* Flattened Config Name Space - Reduce collisions for implementors by removing `config` package
+* New Authentication Options - alters the configuration options used to instantiate Ziti SDK contexts. This impacts
+  context instantiation signatures.
+* New Internal Edge Client & Management clients using `edge-apis`
+    * `edge-apis` - A new root level package, `edge-apis` has been added which provides a thin wrapper around the
+      go-swagger
+      generated Edge Client and Management APIs.
+    * Usage of the `edge-apis` package is not required to use the OpenZiti Golang SDK but is exposed for those who which
+      to.
+* API Session Certificates - API Session Certificates allow authentication mechanisms that are not inherently backed by
+  a x509 certificate to obtain ephemeral x509 certificate and interact with an OpenZiti network.
+* Event API - The GoLang SDK now supports an eventing interface that allows implementors to register listeners
+* Browser WASM Compilation support - Compiling the GO SDK to run in WASM browser environments is now supported.
+
+## Flattened Name Space
+
+Previously, the GoLang SDK provided a package named `config` which would collide when used in other projects that also
+contained variables or packages named config. To reduce collisions, the `config` package has been removed. This has
+the following impact:
+
+- The type `config.Config` is now `ziti.Config` for importers
+- Configuration instantiation is no long `config.New*()` but rather `ziti.NewConfig*()`
+- Context instantiation is no longer `ziti.New*()` but rather `ziti.NewContext*()`
+
+## New Authentication Options
+
+It is now possible to create an OpenZiti GoLang SDK Context by using alternative authentication mechanisms such as
+raw private/public keys, JWTs, and Username Passwords (UPDB) in addition to the original configuration file approach.
+This capability is provided by the `edge-apis` package. To make use of these new option, configure them on
+a `ziti.Config`
+
+```go
+creds := edge_apis.NewJwtCredentials(jwtToken)
+creds.CaPool = caPool
+
+cfg := &ziti.Config{
+ZtAPI:       "https://localhost:1280/edge/client/v1",
+Credentials: creds,
+}
+ctx, err := ziti.NewContext(cfg)
+```
+
+Previous file based implementations may still use identity files:
+
+```go
+ctx, err := NewContextFromFile("identity.json")
+```
+
+## `edge-apis`
+
+The packaged `edge-apis` can be used as a standalone way of interacting with the OpenZiti Edge Client and Management
+APIs. They core API functionality is maintained in `openziti/edge-apis` and contains the raw GoSwagger generated API
+clients. The clients in this repository have been wrapped with a thin layer to make authentication easier.
+
+To use the GoLang Ziti SDK one does not have to use this package directly. The Golang SDK uses this package under the
+hood.
+
+To create an instance of either the Client or Management clients, a Credential instance is required. The following
+types are currently supported:
+
+- `IdentityCredentials` - JSON configuration that embeds the controller URL, public/private keys and location. This was
+  the previous only authentication mechanism supported by the Golang SDK
+- `JwtCredentials` - an externally integrating solution that uses controller `external-jwt-signers` to integrate with
+  any JWT
+  providing IdP
+- `CertCredentials` - Raw handling of public and private key GoLang types
+- `UpdbCredentials` - A username/password combination
+
+Creating new Credential instances is enabled through direct instantiation or via helper functions. Here are two
+examples:
+
+```go
+creds := edge_apis.NewCertCredentials([]*x509.Certificate{testIdCerts.cert}, testIdCerts.key)
+creds.CaPool = ziti.GetControllerWellKnownCaPool("https://example.com:1280")
+```
+
+```go
+creds := edge_apis.New([]*x509.Certificate{testIdCerts.cert}, testIdCerts.key)
+creds.CaPool = ziti.GetControllerWellKnownCaPool("https://example.com:1280")
+```
+
+After a credentials instance is created, a client may be created that will authenticate and provide API access.
+
+```go
+creds := edge_apis.New([]*x509.Certificate{testIdCerts.cert}, testIdCerts.key)
+creds.CaPool = ziti.GetControllerWellKnownCaPool("https://example.com:1280")
+
+client := edge_apis.NewClientApiClient(clientApiUrl, nil)
+apiSession, err := client.Authenticate(creds, nil)
+
+fmt.Printf("identity name: %s", apiSession.Identity.Name)
+
+resp, err := client.API.Service.ListServices(service2.NewListServicesParams(), nil)
+```
+
+## API Session Certificates
+
+OpenZiti Controllers support the creation of ephemeral, API Session scoped, x509 Certificates for fully authenticated
+API Sessions.
+These certificates are created automatically by the GoLang SDK when the authentication mechanism provided to the context
+is not backed by a x509 Certificate.
+
+## Event API
+
+OpenZiti Context's returned now support an `Event()` function which exposes the following function calls:
+
+```go
+	// AddServiceAddedListener adds an event listener for the EventServiceAdded event and returns a function to remove
+	// the listener. It is emitted any time a new service definition is received. The service detail provided is the
+	// service that was added.
+	AddServiceAddedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddServiceChangedListener adds an event listener for the EventServiceChanged event and returns a function to remove
+	// the listener. It is emitted any time a known service definition is updated with new values. The service detail
+	// provided is the service that was changed.
+	AddServiceChangedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddServiceRemovedListener adds an event listener for the EventServiceRemoved event and returns a function to remove
+	// the listener. It is emitted any time known service definition is no longer accessible. The service detail
+	// provided is the service that was removed.
+	AddServiceRemovedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddRouterConnectedListener adds an event listener for the EventRouterConnected event and returns a function to remove
+	// the listener. It is emitted any time a router connection is established. The string provided is the router
+	// key.
+	AddRouterConnectedListener(func(Context, string)) func()
+
+	// AddRouterDisconnectedListener adds an event listener for the EventRouterDisconnected event and returns a function to remove
+	// the listener. It is emitted any time a router connection is closed. The string provided is the router
+	// key.
+	AddRouterDisconnectedListener(func(Context, string)) func()
+
+	// AddMfaTotpCodeListener adds an event listener for the EventMfaTotpCode event and returns a function to remove
+	// the listener. It is emitted any time the currently authenticated API Session requires an MFA TOTP Code for
+	// authentication. The authentication query detail and an MfaCodeResponse function are provided. The MfaCodeResponse
+	// should be invoked to answer the MFA TOTP challenge.
+	//
+	// Authentication challenges for MFA are modeled as authentication queries, and is provided to listeners for
+	// informational purposes. This event handler is a specific authentication query that responds to the internal Ziti
+	// MFA TOTP challenge only. All authentication queries, including MFA TOTP ones, are also available through
+	// AddAuthQueryListener, but does not provide typed response callbacks.
+	AddMfaTotpCodeListener(func(Context, *rest_model.AuthQueryDetail, MfaCodeResponse)) func()
+
+	// AddAuthQueryListener adds an event listener for the EventAuthQuery event and returns a function to remove
+	// the listener. The event is emitted any time the current API Session is required to pass additional authentication
+	// challenges - which enabled MFA functionality.
+	AddAuthQueryListener(func(Context, *rest_model.AuthQueryDetail)) func()
+
+	// AddAuthenticationStatePartialListener adds an event listener for the EventAuthenticationStatePartial event and
+	// returns a function to remove the listener. Partial authentication occurs when there are unmet authentication
+	// queries - which are defined by the authentication policy associated with the identity. The
+	// EventAuthQuery or EventMfaTotpCode events will also coincide with this event. Additionally, the authentication
+	// queries that triggered this event are available on the API Session detail in the `AuthQueries` field.
+	//
+	// In the partially authenticated state, a context will have reduced capabilities. It will not be able to
+	// update/list services, create service sessions, etc. It will be able to enroll in TOTP MFA and answer
+	// authentication queries.
+	//
+	// One all authentication queries are answered, the EventAuthenticationStateFull event will be emitted. For
+	// identities that do not have secondary authentication challenges associated with them, this even will never
+	// be emitted.
+	AddAuthenticationStatePartialListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+
+	// AddAuthenticationStateFullListener adds an event listener for the EventAuthenticationStateFull event and
+	// returns a function to remove the listener. Full authentication occurs when there are no unmet authentication
+	// queries - which are defined by the authentication policy associated with the identity. In a fully authenticated
+	// state, the context will be able to perform all client actions.
+	AddAuthenticationStateFullListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+
+	// AddAuthenticationStateUnauthenticatedListener adds an event listener for the EventAuthenticationStateUnauthenticated
+	// event and returns a function to remove the listener. The unauthenticated state occurs when the API session
+	// currently being used is no longer valid. API Sessions may become invalid due to prolonged inactivity due to
+	// network disconnection, the host machine entering a power saving/sleep mode, etc. It may also occur due to
+	// administrative action such as removing specific API Sessions or removing entire identities.
+	//
+	// The API Session detail provided to the listener may be nil. If it is not nil, the API Session detail is the
+	// now expired API Session.
+	AddAuthenticationStateUnauthenticatedListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+```
+
+The above functions allow for the addition of strongly typed event handlers and removal of those listeners with the 
+returned `func()`. These functions do not require knowing the event names or handling type assertions as the events are
+emitted.
+
+The underlying event functionality is provided by `github.com/kataras/go-events` which uses a weakly typed arguments
+for events. The `go-events` interface for event emitters is available for use and will require usage of the documented
+event names in `ziti/events.go`.
+
+All events, either through the strongly typed or weakly typed interface, are called synchronously. Performing operations
+that take longer than a few milliseconds is not suggested. If necessary, when your event handler is called spawn a 
+goroutine to offload any extended processing.
+
+Synchronous Event:
+```go
+ctx, err := ziti.NewContext(cfg)
+ctx.Events().AddServiceAddedListener(func(detail *rest_model.ServiceDetail) {
+    fmt.Printf("New service %s", *detail.Name)
+})
+```
+
+Asynchronous Event:
+```go
+ctx, err := ziti.NewContext(cfg)
+ctx.Events().AddServiceAddedListener(func(detail *rest_model.ServiceDetail) {
+    go func(){
+		fmt.Printf("New service %s", *detail.Name
+    }()
+})
+```
+
+# Browser WASM Compilation support
+
+Compiling projects that use the GO SDK with `js` tag will now alter internal components to deal with running in a 
+browser environment. This includes enabling WebSocket Secure (WSS) connections to Edge Routers.
+
+`go build ./my-project -tags=js`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## What's New
 
-* Change log - This change log was added and is a reelection of all changes from `v0.20.0` to `v0.20.23`
+* Change log - This change log was added and is a reflection of all changes from `v0.20.0` to `v0.20.23`
 * Flattened Config Name Space - Reduce collisions for implementors by removing `config` package
 * New Authentication Options - alters the configuration options used to instantiate Ziti SDK contexts. This impacts
   context instantiation signatures.
@@ -110,77 +110,75 @@ is not backed by a x509 Certificate.
 OpenZiti Context's returned now support an `Event()` function which exposes the following function calls:
 
 ```go
-	// AddServiceAddedListener adds an event listener for the EventServiceAdded event and returns a function to remove
-	// the listener. It is emitted any time a new service definition is received. The service detail provided is the
-	// service that was added.
-	AddServiceAddedListener(func(Context, *rest_model.ServiceDetail)) func()
+// AddServiceAddedListener adds an event listener for the EventServiceAdded event and returns a function to remove
+// the listener. It is emitted any time a new service definition is received. The service detail provided is the
+// service that was added.
+AddServiceAddedListener(func(Context, *rest_model.ServiceDetail)) func()
 
-	// AddServiceChangedListener adds an event listener for the EventServiceChanged event and returns a function to remove
-	// the listener. It is emitted any time a known service definition is updated with new values. The service detail
-	// provided is the service that was changed.
-	AddServiceChangedListener(func(Context, *rest_model.ServiceDetail)) func()
+// AddServiceChangedListener adds an event listener for the EventServiceChanged event and returns a function to remove
+// the listener. It is emitted any time a known service definition is updated with new values. The service detail
+// provided is the service that was changed.
+AddServiceChangedListener(func(Context, *rest_model.ServiceDetail)) func()
 
-	// AddServiceRemovedListener adds an event listener for the EventServiceRemoved event and returns a function to remove
-	// the listener. It is emitted any time known service definition is no longer accessible. The service detail
-	// provided is the service that was removed.
-	AddServiceRemovedListener(func(Context, *rest_model.ServiceDetail)) func()
+// AddServiceRemovedListener adds an event listener for the EventServiceRemoved event and returns a function to remove
+// the listener. It is emitted any time known service definition is no longer accessible. The service detail
+// provided is the service that was removed.
+AddServiceRemovedListener(func(Context, *rest_model.ServiceDetail)) func()
 
-	// AddRouterConnectedListener adds an event listener for the EventRouterConnected event and returns a function to remove
-	// the listener. It is emitted any time a router connection is established. The string provided is the router
-	// key.
-	AddRouterConnectedListener(func(Context, string)) func()
+// AddRouterConnectedListener adds an event listener for the EventRouterConnected event and returns a function to remove
+// the listener. It is emitted any time a router connection is established. The strings provided are router name and connection address.
+AddRouterConnectedListener(func(ztx Context, name string, addr string)) func()
 
-	// AddRouterDisconnectedListener adds an event listener for the EventRouterDisconnected event and returns a function to remove
-	// the listener. It is emitted any time a router connection is closed. The string provided is the router
-	// key.
-	AddRouterDisconnectedListener(func(Context, string)) func()
+// AddRouterDisconnectedListener adds an event listener for the EventRouterDisconnected event and returns a function to remove
+// the listener. It is emitted any time a router connection is closed. The strings provided are router name and connection address.
+AddRouterDisconnectedListener(func(ztx Context, name string, addr string)) func()
 
-	// AddMfaTotpCodeListener adds an event listener for the EventMfaTotpCode event and returns a function to remove
-	// the listener. It is emitted any time the currently authenticated API Session requires an MFA TOTP Code for
-	// authentication. The authentication query detail and an MfaCodeResponse function are provided. The MfaCodeResponse
-	// should be invoked to answer the MFA TOTP challenge.
-	//
-	// Authentication challenges for MFA are modeled as authentication queries, and is provided to listeners for
-	// informational purposes. This event handler is a specific authentication query that responds to the internal Ziti
-	// MFA TOTP challenge only. All authentication queries, including MFA TOTP ones, are also available through
-	// AddAuthQueryListener, but does not provide typed response callbacks.
-	AddMfaTotpCodeListener(func(Context, *rest_model.AuthQueryDetail, MfaCodeResponse)) func()
+// AddMfaTotpCodeListener adds an event listener for the EventMfaTotpCode event and returns a function to remove
+// the listener. It is emitted any time the currently authenticated API Session requires an MFA TOTP Code for
+// authentication. The authentication query detail and an MfaCodeResponse function are provided. The MfaCodeResponse
+// should be invoked to answer the MFA TOTP challenge.
+//
+// Authentication challenges for MFA are modeled as authentication queries, and is provided to listeners for
+// informational purposes. This event handler is a specific authentication query that responds to the internal Ziti
+// MFA TOTP challenge only. All authentication queries, including MFA TOTP ones, are also available through
+// AddAuthQueryListener, but does not provide typed response callbacks.
+AddMfaTotpCodeListener(func(Context, *rest_model.AuthQueryDetail, MfaCodeResponse)) func()
 
-	// AddAuthQueryListener adds an event listener for the EventAuthQuery event and returns a function to remove
-	// the listener. The event is emitted any time the current API Session is required to pass additional authentication
-	// challenges - which enabled MFA functionality.
-	AddAuthQueryListener(func(Context, *rest_model.AuthQueryDetail)) func()
+// AddAuthQueryListener adds an event listener for the EventAuthQuery event and returns a function to remove
+// the listener. The event is emitted any time the current API Session is required to pass additional authentication
+// challenges - which enabled MFA functionality.
+AddAuthQueryListener(func(Context, *rest_model.AuthQueryDetail)) func()
 
-	// AddAuthenticationStatePartialListener adds an event listener for the EventAuthenticationStatePartial event and
-	// returns a function to remove the listener. Partial authentication occurs when there are unmet authentication
-	// queries - which are defined by the authentication policy associated with the identity. The
-	// EventAuthQuery or EventMfaTotpCode events will also coincide with this event. Additionally, the authentication
-	// queries that triggered this event are available on the API Session detail in the `AuthQueries` field.
-	//
-	// In the partially authenticated state, a context will have reduced capabilities. It will not be able to
-	// update/list services, create service sessions, etc. It will be able to enroll in TOTP MFA and answer
-	// authentication queries.
-	//
-	// One all authentication queries are answered, the EventAuthenticationStateFull event will be emitted. For
-	// identities that do not have secondary authentication challenges associated with them, this even will never
-	// be emitted.
-	AddAuthenticationStatePartialListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+// AddAuthenticationStatePartialListener adds an event listener for the EventAuthenticationStatePartial event and
+// returns a function to remove the listener. Partial authentication occurs when there are unmet authentication
+// queries - which are defined by the authentication policy associated with the identity. The
+// EventAuthQuery or EventMfaTotpCode events will also coincide with this event. Additionally, the authentication
+// queries that triggered this event are available on the API Session detail in the `AuthQueries` field.
+//
+// In the partially authenticated state, a context will have reduced capabilities. It will not be able to
+// update/list services, create service sessions, etc. It will be able to enroll in TOTP MFA and answer
+// authentication queries.
+//
+// One all authentication queries are answered, the EventAuthenticationStateFull event will be emitted. For
+// identities that do not have secondary authentication challenges associated with them, this even will never
+// be emitted.
+AddAuthenticationStatePartialListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
 
-	// AddAuthenticationStateFullListener adds an event listener for the EventAuthenticationStateFull event and
-	// returns a function to remove the listener. Full authentication occurs when there are no unmet authentication
-	// queries - which are defined by the authentication policy associated with the identity. In a fully authenticated
-	// state, the context will be able to perform all client actions.
-	AddAuthenticationStateFullListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+// AddAuthenticationStateFullListener adds an event listener for the EventAuthenticationStateFull event and
+// returns a function to remove the listener. Full authentication occurs when there are no unmet authentication
+// queries - which are defined by the authentication policy associated with the identity. In a fully authenticated
+// state, the context will be able to perform all client actions.
+AddAuthenticationStateFullListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
 
-	// AddAuthenticationStateUnauthenticatedListener adds an event listener for the EventAuthenticationStateUnauthenticated
-	// event and returns a function to remove the listener. The unauthenticated state occurs when the API session
-	// currently being used is no longer valid. API Sessions may become invalid due to prolonged inactivity due to
-	// network disconnection, the host machine entering a power saving/sleep mode, etc. It may also occur due to
-	// administrative action such as removing specific API Sessions or removing entire identities.
-	//
-	// The API Session detail provided to the listener may be nil. If it is not nil, the API Session detail is the
-	// now expired API Session.
-	AddAuthenticationStateUnauthenticatedListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+// AddAuthenticationStateUnauthenticatedListener adds an event listener for the EventAuthenticationStateUnauthenticated
+// event and returns a function to remove the listener. The unauthenticated state occurs when the API session
+// currently being used is no longer valid. API Sessions may become invalid due to prolonged inactivity due to
+// network disconnection, the host machine entering a power saving/sleep mode, etc. It may also occur due to
+// administrative action such as removing specific API Sessions or removing entire identities.
+//
+// The API Session detail provided to the listener may be nil. If it is not nil, the API Session detail is the
+// now expired API Session.
+AddAuthenticationStateUnauthenticatedListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
 ```
 
 The above functions allow for the addition of strongly typed event handlers and removal of those listeners with the 

--- a/edge-apis/clients.go
+++ b/edge-apis/clients.go
@@ -1,3 +1,19 @@
+/*
+	Copyright 2019 NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 package edge_apis
 
 import (

--- a/edge-apis/credentials.go
+++ b/edge-apis/credentials.go
@@ -31,6 +31,10 @@ type Credentials interface {
 	// AddHeader adds a header to the request.
 	AddHeader(key, value string)
 
+	// AddJWT adds additional JWTs to the credentials. Used to satisfy secondary authentication/MFA requirements. The
+	// provided token should be the base64 encoded version of the token.
+	AddJWT(string)
+
 	// AuthenticateRequest authenticates an outgoing request.
 	AuthenticateRequest(runtime.ClientRequest, strfmt.Registry) error
 
@@ -92,6 +96,12 @@ type BaseCredentials struct {
 
 	// CaPool will override the client's default certificate pool if set to a non-nil value.
 	CaPool *x509.CertPool
+}
+
+// AddJWT adds additional JWTs to the credentials. Used to satisfy secondary authentication/MFA requirements. The
+// provided token should be the base64 encoded version of the token.
+func (c *BaseCredentials) AddJWT(token string) {
+	c.Headers.Add("authorization", "Bearer "+token)
 }
 
 // Payload will produce the object used to construct the body of an authentication requests. The base version

--- a/example/zping/go.work.sum
+++ b/example/zping/go.work.sum
@@ -60,9 +60,7 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -101,7 +99,6 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/michaelquigley/pfxlog v0.3.1/go.mod h1:pwJmJ9nN787xk9U+0z8/5nP2GMhU6GGCTfgBWGpiXaQ=
@@ -128,8 +125,10 @@ github.com/parallaxsecond/parsec-client-go v0.0.0-20220111122524-cb78842db373/go
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pion/dtls/v2 v2.2.6/go.mod h1:t8fWJCIquY5rlQZwA2yWxUS1+OCrAdXrhVKXB5oD/wY=
+github.com/pion/dtls/v2 v2.2.7/go.mod h1:8WiMkebSHFD0T+dIU+UeBaoV7kDhOW5oDCzZ7WZ/F9s=
 github.com/pion/logging v0.2.2/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/transport/v2 v2.0.2/go.mod h1:vrz6bUbFr/cjdwbnxq8OdDDzHf7JJfGsIRkxfpZoTA0=
+github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1Aq29pGcU5g=
 github.com/pion/udp/v2 v2.0.1/go.mod h1:B7uvTMP00lzWdyMr/1PVZXtV3wpPIxBRd4Wl6AksXn8=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -216,6 +215,7 @@ golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
@@ -247,12 +247,12 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
+golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
 golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0
+	github.com/kataras/go-events v0.0.3
 	github.com/michaelquigley/pfxlog v0.6.10
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/kataras/go-events v0.0.3 h1:o5YK53uURXtrlg7qE/vovxd/yKOJcLuFtPQbf1rYMC4=
+github.com/kataras/go-events v0.0.3/go.mod h1:bFBgtzwwzrag7kQmGuU1ZaVxhK2qseYPQomXoVEMsj4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/ziti/config.go
+++ b/ziti/config.go
@@ -82,6 +82,9 @@ func NewConfigFromFile(confFile string) (*Config, error) {
 
 // GetControllerWellKnownCaPool will return a x509.CertPool. The target controller will not be verified via TLS and
 // must be verified by some other means (i.e. enrollment JWT token).
+//
+// WARNING: This call is unauthenticated and should only be used for example purposes or expliciltly when an unauthenticated
+// request is required.
 func GetControllerWellKnownCaPool(controllerAddr string) (*x509.CertPool, error) {
 	return rest_util.GetControllerWellKnownCaPool(controllerAddr)
 }

--- a/ziti/contexts.go
+++ b/ziti/contexts.go
@@ -26,6 +26,7 @@
 package ziti
 
 import (
+	"github.com/kataras/go-events"
 	"github.com/openziti/edge-api/rest_model"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
 	"github.com/openziti/sdk-golang/ziti/edge"
@@ -78,8 +79,9 @@ func NewContextWithOpts(cfg *Config, options *Options) (Context, error) {
 		Id:                NewId(),
 		routerConnections: cmap.New[edge.RouterConn](),
 		options:           options,
-		authQueryHandlers: map[string]func(query *rest_model.AuthQueryDetail, resp func(code string) error) error{},
+		authQueryHandlers: map[string]func(query *rest_model.AuthQueryDetail, response MfaCodeResponse) error{},
 		closeNotify:       make(chan struct{}),
+		EventEmmiter:      events.New(),
 	}
 
 	if cfg == nil {

--- a/ziti/edge/network/factory.go
+++ b/ziti/edge/network/factory.go
@@ -18,10 +18,10 @@ package network
 
 import (
 	"github.com/michaelquigley/pfxlog"
-	"github.com/openziti/secretstream/kx"
 	"github.com/openziti/channel/v2"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/sdk-golang/ziti/edge"
+	"github.com/openziti/secretstream/kx"
 )
 
 type RouterConnOwner interface {
@@ -126,7 +126,11 @@ func (conn *routerConn) Listen(service *rest_model.ServiceDetail, session *rest_
 }
 
 func (conn *routerConn) Close() error {
-	return conn.ch.Close()
+	if !conn.ch.IsClosed() {
+		return conn.ch.Close()
+	}
+
+	return nil
 }
 
 func (conn *routerConn) IsClosed() bool {

--- a/ziti/events.go
+++ b/ziti/events.go
@@ -47,14 +47,16 @@ const (
 	//
 	// Arguments:
 	// 1) Context - the context that triggered the listener
-	// 2) routerKey `string` - A string that uniquely identifies a router connection
+	// 2) routerName `string` - The string name of the target router
+	// 3) routerKey `string` - A string that uniquely identifies a router connection
 	EventRouterConnected = events.EventName("router-connected")
 
 	// EventRouterDisconnected is emitted when a connection to an Edge Router is disconnected.
 	//
 	// Arguments:
 	// 1) Context - the context that triggered the listener
-	// 2) routerKey `string` - A string that uniquely identifies a router connection
+	// 2) routerName `string` - The string name of the target router
+	// 3) routerKey `string` - A string that uniquely identifies a router connection
 	EventRouterDisconnected = events.EventName("router-disconnected")
 
 	// EventMfaTotpCode is emitted when a Ziti context requires an MFA TOTP code to proceed with authentication.
@@ -119,14 +121,12 @@ type Eventer interface {
 	AddServiceRemovedListener(func(Context, *rest_model.ServiceDetail)) func()
 
 	// AddRouterConnectedListener adds an event listener for the EventRouterConnected event and returns a function to remove
-	// the listener. It is emitted any time a router connection is established. The string provided is the router
-	// key.
-	AddRouterConnectedListener(func(Context, string)) func()
+	// the listener. It is emitted any time a router connection is established. The strings provided are router name and connection address.
+	AddRouterConnectedListener(func(ztx Context, name string, addr string)) func()
 
 	// AddRouterDisconnectedListener adds an event listener for the EventRouterDisconnected event and returns a function to remove
-	// the listener. It is emitted any time a router connection is closed. The string provided is the router
-	// key.
-	AddRouterDisconnectedListener(func(Context, string)) func()
+	// the listener. It is emitted any time a router connection is closed. The strings provided are router name and connection address.
+	AddRouterDisconnectedListener(func(ztx Context, name string, addr string)) func()
 
 	// AddMfaTotpCodeListener adds an event listener for the EventMfaTotpCode event and returns a function to remove
 	// the listener. It is emitted any time the currently authenticated API Session requires an MFA TOTP Code for

--- a/ziti/events.go
+++ b/ziti/events.go
@@ -1,0 +1,210 @@
+/*
+	Copyright 2019 NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package ziti
+
+import (
+	"github.com/kataras/go-events"
+	"github.com/openziti/edge-api/rest_model"
+)
+
+const (
+	// EventServiceAdded is emitted when a new service is detected by a Ziti SDK context.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) serviceDetail`*rest_model.ServiceDetail` - The full detail record of the service
+	EventServiceAdded = events.EventName("service-new")
+
+	// EventServiceChanged is emitted when an existing service undergoes a change in its definition.
+	//
+	//Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) serviceDetail`*rest_model.ServiceDetail` - The full detail record of the service
+	EventServiceChanged = events.EventName("service-changed")
+
+	// EventServiceRemoved is emitted when a service is no longer available.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) serviceDetail`*rest_model.ServiceDetail` - The full detail record of the service
+	EventServiceRemoved = events.EventName("service-removed")
+
+	// EventRouterConnected is emitted when a connection to an Edge Router is established.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) routerKey `string` - A string that uniquely identifies a router connection
+	EventRouterConnected = events.EventName("router-connected")
+
+	// EventRouterDisconnected is emitted when a connection to an Edge Router is disconnected.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) routerKey `string` - A string that uniquely identifies a router connection
+	EventRouterDisconnected = events.EventName("router-disconnected")
+
+	// EventMfaTotpCode is emitted when a Ziti context requires an MFA TOTP code to proceed with authentication.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) query *rest_model.AuthQueryDetail - details the authentication query causing the MFA Code request
+	// 3) codeResponse MfaCodeResponse - a function that accepts a string to return to the authentication process. This codeResponse should be invoked with the user supplied TOTP code.
+	EventMfaTotpCode = events.EventName("mfa-totp-code")
+
+	// EventAuthQuery is emitted when a Ziti context requires an answer to an authentication query. MFA TOTP is
+	// modeled as an authentication query as well and will also trigger the event EventMfaTotpCode.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) query `*rest_model.AuthQueryDetail` - the details of the authentication query
+	//
+	EventAuthQuery = events.EventName("auth-query")
+
+	// EventAuthenticationStatePartial emitted if a context acquires an API Session that is in a partially authenticated state. Partial authentication
+	// allows for interaction w/ MFA TOTP enrollment and answering authentication queries. It does not allow access to service.
+	// This event may or may not be emitted depending on the authentication policy the identity is acting under.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) apiSession *rest_model.CurrentAPISessionDetail - details of the current API Session
+	EventAuthenticationStatePartial = events.EventName("auth-state-partial")
+
+	// EventAuthenticationStateFull is emitted when a context acquires an API Session that is fully authenticated. The
+	// context will have access to services.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) apiSession *rest_model.CurrentApiSessionDetail - details of the current API Session
+	EventAuthenticationStateFull = events.EventName("auth-state-full")
+
+	// EventAuthenticationStateUnauthenticated is emitted when a context has reverted to an unauthenticated state after
+	// being fully or partially authenticated.
+	//
+	// Arguments:
+	// 1) Context - the context that triggered the listener
+	// 2) apiSession *rest_model.CurrentApiSessionDetail - details of the invalid API Session
+	EventAuthenticationStateUnauthenticated = events.EventName("auth-state-unauthenticated")
+)
+
+// Eventer provides types methods for adding event listeners to a context and exposes some weakly typed functions
+// that are useful for debugging/testing.
+type Eventer interface {
+	// AddServiceAddedListener adds an event listener for the EventServiceAdded event and returns a function to remove
+	// the listener. It is emitted any time a new service definition is received. The service detail provided is the
+	// service that was added.
+	AddServiceAddedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddServiceChangedListener adds an event listener for the EventServiceChanged event and returns a function to remove
+	// the listener. It is emitted any time a known service definition is updated with new values. The service detail
+	// provided is the service that was changed.
+	AddServiceChangedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddServiceRemovedListener adds an event listener for the EventServiceRemoved event and returns a function to remove
+	// the listener. It is emitted any time known service definition is no longer accessible. The service detail
+	// provided is the service that was removed.
+	AddServiceRemovedListener(func(Context, *rest_model.ServiceDetail)) func()
+
+	// AddRouterConnectedListener adds an event listener for the EventRouterConnected event and returns a function to remove
+	// the listener. It is emitted any time a router connection is established. The string provided is the router
+	// key.
+	AddRouterConnectedListener(func(Context, string)) func()
+
+	// AddRouterDisconnectedListener adds an event listener for the EventRouterDisconnected event and returns a function to remove
+	// the listener. It is emitted any time a router connection is closed. The string provided is the router
+	// key.
+	AddRouterDisconnectedListener(func(Context, string)) func()
+
+	// AddMfaTotpCodeListener adds an event listener for the EventMfaTotpCode event and returns a function to remove
+	// the listener. It is emitted any time the currently authenticated API Session requires an MFA TOTP Code for
+	// authentication. The authentication query detail and an MfaCodeResponse function are provided. The MfaCodeResponse
+	// should be invoked to answer the MFA TOTP challenge.
+	//
+	// Authentication challenges for MFA are modeled as authentication queries, and is provided to listeners for
+	// informational purposes. This event handler is a specific authentication query that responds to the internal Ziti
+	// MFA TOTP challenge only. All authentication queries, including MFA TOTP ones, are also available through
+	// AddAuthQueryListener, but does not provide typed response callbacks.
+	AddMfaTotpCodeListener(func(Context, *rest_model.AuthQueryDetail, MfaCodeResponse)) func()
+
+	// AddAuthQueryListener adds an event listener for the EventAuthQuery event and returns a function to remove
+	// the listener. The event is emitted any time the current API Session is required to pass additional authentication
+	// challenges - which enabled MFA functionality.
+	AddAuthQueryListener(func(Context, *rest_model.AuthQueryDetail)) func()
+
+	// AddAuthenticationStatePartialListener adds an event listener for the EventAuthenticationStatePartial event and
+	// returns a function to remove the listener. Partial authentication occurs when there are unmet authentication
+	// queries - which are defined by the authentication policy associated with the identity. The
+	// EventAuthQuery or EventMfaTotpCode events will also coincide with this event. Additionally, the authentication
+	// queries that triggered this event are available on the API Session detail in the `AuthQueries` field.
+	//
+	// In the partially authenticated state, a context will have reduced capabilities. It will not be able to
+	// update/list services, create service sessions, etc. It will be able to enroll in TOTP MFA and answer
+	// authentication queries.
+	//
+	// One all authentication queries are answered, the EventAuthenticationStateFull event will be emitted. For
+	// identities that do not have secondary authentication challenges associated with them, this even will never
+	// be emitted.
+	AddAuthenticationStatePartialListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+
+	// AddAuthenticationStateFullListener adds an event listener for the EventAuthenticationStateFull event and
+	// returns a function to remove the listener. Full authentication occurs when there are no unmet authentication
+	// queries - which are defined by the authentication policy associated with the identity. In a fully authenticated
+	// state, the context will be able to perform all client actions.
+	AddAuthenticationStateFullListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+
+	// AddAuthenticationStateUnauthenticatedListener adds an event listener for the EventAuthenticationStateUnauthenticated
+	// event and returns a function to remove the listener. The unauthenticated state occurs when the API session
+	// currently being used is no longer valid. API Sessions may become invalid due to prolonged inactivity due to
+	// network disconnection, the host machine entering a power saving/sleep mode, etc. It may also occur due to
+	// administrative action such as removing specific API Sessions or removing entire identities.
+	//
+	// The API Session detail provided to the listener may be nil. If it is not nil, the API Session detail is the
+	// now expired API Session.
+	AddAuthenticationStateUnauthenticatedListener(func(Context, *rest_model.CurrentAPISessionDetail)) func()
+
+	// AddListener is an alias for .On(eventName, listener).
+	AddListener(events.EventName, ...events.Listener)
+
+	// EventNames returns an array listing the events for which the emitter has registered listeners.
+	// The values in the array will be strings.
+	EventNames() []events.EventName
+
+	// GetMaxListeners returns the max listeners for this emmiter
+	// see SetMaxListeners
+	GetMaxListeners() int
+
+	// ListenerCount returns the length of all registered listeners to a particular event
+	ListenerCount(events.EventName) int
+
+	// Listeners returns a copy of the array of listeners for the event named eventName.
+	Listeners(events.EventName) []events.Listener
+
+	// On registers a particular listener for an event, func receiver parameter(s) is/are optional
+	On(events.EventName, ...events.Listener)
+
+	// Once adds a one-time listener function for the event named eventName.
+	// The next time eventName is triggered, this listener is removed and then invoked.
+	Once(events.EventName, ...events.Listener)
+
+	// RemoveAllListeners removes all listeners, or those of the specified eventName.
+	// Note that it will remove the event itself.
+	// Returns an indicator if event and listeners were found before the remove.
+	RemoveAllListeners(events.EventName) bool
+
+	// RemoveListener removes given listener from the event named eventName.
+	// Returns an indicator whether listener was removed
+	RemoveListener(events.EventName, events.Listener) bool
+}

--- a/ziti/options.go
+++ b/ziti/options.go
@@ -17,7 +17,14 @@ type serviceCB func(eventType ServiceEventType, service *rest_model.ServiceDetai
 
 type Options struct {
 	RefreshInterval time.Duration
-	OnContextReady  func(ctx Context)
+
+	// Deprecated: OnContextReady is a callback that is invoked after the first successful authentication request. It
+	// does not delineate between fully and partially authenticated API Sessions. Use context.AddListener() with the events
+	// EventAuthenticationStateFull, EventAuthenticationStatePartial, EventAuthenticationStateUnAuthenticated instead.
+	OnContextReady func(ctx Context)
+
+	// Deprecated: OnServiceUpdate is a callback that is invoked when a service changes its definition.
+	// Use `zitiContext.AddListener(<eventName>, handler)` where `eventName` may be EventServiceAdded, EventServiceChanged, EventServiceRemoved.
 	OnServiceUpdate serviceCB
 }
 

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -189,7 +189,7 @@ func (context *ContextImpl) AddServiceAddedListener(handler func(Context, *rest_
 		}
 
 		if details == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, details)
@@ -211,7 +211,7 @@ func (context *ContextImpl) AddServiceChangedListener(handler func(Context, *res
 		}
 
 		if details == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, details)
@@ -233,7 +233,7 @@ func (context *ContextImpl) AddServiceRemovedListener(handler func(Context, *res
 		}
 
 		if details == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, details)
@@ -303,7 +303,7 @@ func (context *ContextImpl) AddMfaTotpCodeListener(handler func(Context, *rest_m
 		}
 
 		if authQuery == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		responder, ok := args[1].(MfaCodeResponse)
@@ -313,7 +313,7 @@ func (context *ContextImpl) AddMfaTotpCodeListener(handler func(Context, *rest_m
 		}
 
 		if responder == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, authQuery, responder)
@@ -335,7 +335,7 @@ func (context *ContextImpl) AddAuthQueryListener(handler func(Context, *rest_mod
 		}
 
 		if authQuery == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, authQuery)
@@ -357,7 +357,7 @@ func (context *ContextImpl) AddAuthenticationStatePartialListener(handler func(C
 		}
 
 		if apiSession == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, apiSession)
@@ -379,7 +379,7 @@ func (context *ContextImpl) AddAuthenticationStateFullListener(handler func(Cont
 		}
 
 		if apiSession == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, apiSession)
@@ -401,7 +401,7 @@ func (context *ContextImpl) AddAuthenticationStateUnauthenticatedListener(handle
 		}
 
 		if apiSession == nil {
-			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+			pfxlog.Logger().Fatalf("expected arg[0] was nil, unexpected")
 		}
 
 		handler(context, apiSession)

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-openapi/strfmt"
+	"github.com/kataras/go-events"
 	"github.com/openziti/edge-api/rest_client_api_client/authentication"
 	"github.com/openziti/edge-api/rest_client_api_client/service"
 	rest_session "github.com/openziti/edge-api/rest_client_api_client/session"
@@ -63,6 +64,9 @@ const (
 	SessionDial = rest_model.DialBindDial
 	SessionBind = rest_model.DialBindBind
 )
+
+// MfaCodeResponse is a handler used to return a string (TOTP) code
+type MfaCodeResponse func(code string) error
 
 // Context is the main interface for SDK instances that may be used to authenticate, connect to services, or host
 // services.
@@ -130,8 +134,9 @@ type Context interface {
 	// Close closes any connections open to edge routers
 	Close()
 
-	// AddZitiMfaHandler adds a Ziti MFA handler, invoked during authentication
-	AddZitiMfaHandler(handler func(query *rest_model.AuthQueryDetail, resp func(code string) error) error)
+	// Deprecated: AddZitiMfaHandler adds a Ziti MFA handler, invoked during authentication.
+	// Replaced with event functionality. Use `zitiContext.AddListener(MfaTotpCode, handler)` instead.
+	AddZitiMfaHandler(handler func(query *rest_model.AuthQueryDetail, resp MfaCodeResponse) error)
 
 	// EnrollZitiMfa will attempt to enable TOTP 2FA on the currently authenticating identity if not already enrolled.
 	EnrollZitiMfa() (*rest_model.DetailMfa, error)
@@ -147,6 +152,8 @@ type Context interface {
 
 	// SetId allows the setting of a context's id
 	SetId(id string)
+
+	Events() Eventer
 }
 
 var _ Context = &ContextImpl{}
@@ -168,7 +175,243 @@ type ContextImpl struct {
 
 	closed            atomic.Bool
 	closeNotify       chan struct{}
-	authQueryHandlers map[string]func(query *rest_model.AuthQueryDetail, resp func(code string) error) error
+	authQueryHandlers map[string]func(query *rest_model.AuthQueryDetail, response MfaCodeResponse) error
+
+	events.EventEmmiter
+}
+
+func (context *ContextImpl) AddServiceAddedListener(handler func(Context, *rest_model.ServiceDetail)) func() {
+	listener := func(args ...interface{}) {
+		details, ok := args[0].(*rest_model.ServiceDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", details, args[0])
+		}
+
+		if details == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, details)
+	}
+
+	context.AddListener(EventServiceAdded, listener)
+
+	return func() {
+		context.RemoveListener(EventServiceAdded, listener)
+	}
+}
+
+func (context *ContextImpl) AddServiceChangedListener(handler func(Context, *rest_model.ServiceDetail)) func() {
+	listener := func(args ...interface{}) {
+		details, ok := args[0].(*rest_model.ServiceDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", details, args[0])
+		}
+
+		if details == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, details)
+	}
+
+	context.AddListener(EventServiceChanged, listener)
+
+	return func() {
+		context.RemoveListener(EventServiceChanged, listener)
+	}
+}
+
+func (context *ContextImpl) AddServiceRemovedListener(handler func(Context, *rest_model.ServiceDetail)) func() {
+	listener := func(args ...interface{}) {
+		details, ok := args[0].(*rest_model.ServiceDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", details, args[0])
+		}
+
+		if details == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, details)
+	}
+
+	context.AddListener(EventServiceRemoved, listener)
+
+	return func() {
+		context.RemoveListener(EventServiceRemoved, listener)
+	}
+}
+
+func (context *ContextImpl) AddRouterConnectedListener(handler func(Context, string)) func() {
+	listener := func(args ...interface{}) {
+		key, ok := args[0].(string)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", key, args[0])
+		}
+
+		if key == "" {
+			pfxlog.Logger().Fatalf("expected arg[0] was empty string, unexpected")
+		}
+
+		handler(context, key)
+	}
+
+	context.AddListener(EventRouterConnected, listener)
+
+	return func() {
+		context.RemoveListener(EventRouterConnected, listener)
+	}
+}
+
+func (context *ContextImpl) AddRouterDisconnectedListener(handler func(Context, string)) func() {
+	listener := func(args ...interface{}) {
+		key, ok := args[0].(string)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", key, args[0])
+		}
+
+		if key == "" {
+			pfxlog.Logger().Fatalf("expected arg[0] was empty string, unexpected")
+		}
+
+		handler(context, key)
+	}
+
+	context.AddListener(EventRouterDisconnected, listener)
+
+	return func() {
+		context.RemoveListener(EventRouterDisconnected, listener)
+	}
+}
+
+func (context *ContextImpl) AddMfaTotpCodeListener(handler func(Context, *rest_model.AuthQueryDetail, MfaCodeResponse)) func() {
+	listener := func(args ...interface{}) {
+		authQuery, ok := args[0].(*rest_model.AuthQueryDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", authQuery, args[0])
+		}
+
+		if authQuery == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		responder, ok := args[1].(MfaCodeResponse)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[1] to %T was %T", responder, args[1])
+		}
+
+		if responder == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, authQuery, responder)
+	}
+
+	context.AddListener(EventMfaTotpCode, listener)
+
+	return func() {
+		context.RemoveListener(EventMfaTotpCode, listener)
+	}
+}
+
+func (context *ContextImpl) AddAuthQueryListener(handler func(Context, *rest_model.AuthQueryDetail)) func() {
+	listener := func(args ...interface{}) {
+		authQuery, ok := args[0].(*rest_model.AuthQueryDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", authQuery, args[0])
+		}
+
+		if authQuery == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, authQuery)
+	}
+
+	context.AddListener(EventAuthQuery, listener)
+
+	return func() {
+		context.RemoveListener(EventAuthQuery, listener)
+	}
+}
+
+func (context *ContextImpl) AddAuthenticationStatePartialListener(handler func(Context, *rest_model.CurrentAPISessionDetail)) func() {
+	listener := func(args ...interface{}) {
+		apiSession, ok := args[0].(*rest_model.CurrentAPISessionDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", apiSession, args[0])
+		}
+
+		if apiSession == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, apiSession)
+	}
+
+	context.AddListener(EventAuthenticationStatePartial, listener)
+
+	return func() {
+		context.RemoveListener(EventAuthenticationStatePartial, listener)
+	}
+}
+
+func (context *ContextImpl) AddAuthenticationStateFullListener(handler func(Context, *rest_model.CurrentAPISessionDetail)) func() {
+	listener := func(args ...interface{}) {
+		apiSession, ok := args[0].(*rest_model.CurrentAPISessionDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", apiSession, args[0])
+		}
+
+		if apiSession == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, apiSession)
+	}
+
+	context.AddListener(EventAuthenticationStateFull, listener)
+
+	return func() {
+		context.RemoveListener(EventAuthenticationStateFull, listener)
+	}
+}
+
+func (context *ContextImpl) AddAuthenticationStateUnauthenticatedListener(handler func(Context, *rest_model.CurrentAPISessionDetail)) func() {
+	listener := func(args ...interface{}) {
+		apiSession, ok := args[0].(*rest_model.CurrentAPISessionDetail)
+
+		if !ok {
+			pfxlog.Logger().Fatalf("could not convert args[0] to %T was %T", apiSession, args[0])
+		}
+
+		if apiSession == nil {
+			pfxlog.Logger().Fatalf("expected arg[0] was nill, unexpected")
+		}
+
+		handler(context, apiSession)
+	}
+
+	context.AddListener(EventAuthenticationStateUnauthenticated, listener)
+
+	return func() {
+		context.RemoveListener(EventAuthenticationStateUnauthenticated, listener)
+	}
+}
+
+func (context *ContextImpl) Events() Eventer {
+	return context
 }
 
 func (context *ContextImpl) GetId() string {
@@ -195,9 +438,10 @@ func (context *ContextImpl) Sessions() ([]*rest_model.SessionDetail, error) {
 	return sessions, nil
 }
 
-func (context *ContextImpl) OnClose(factory edge.RouterConn) {
-	logrus.Debugf("connection to router [%s] was closed", factory.Key())
-	context.routerConnections.Remove(factory.Key())
+func (context *ContextImpl) OnClose(routerConn edge.RouterConn) {
+	logrus.Debugf("connection to router [%s] was closed", routerConn.Key())
+	context.Emit(EventRouterDisconnected, routerConn.Key())
+	context.routerConnections.Remove(routerConn.Key())
 }
 
 func (context *ContextImpl) processServiceUpdates(services []*rest_model.ServiceDetail) {
@@ -216,7 +460,10 @@ func (context *ContextImpl) processServiceUpdates(services []*rest_model.Service
 			if context.options.OnServiceUpdate != nil {
 				context.options.OnServiceUpdate(ServiceRemoved, svc)
 			}
+			context.Emit(EventServiceRemoved, svc)
+
 			context.deleteServiceSessions(*svc.ID)
+
 		}
 	})
 
@@ -238,6 +485,12 @@ func (context *ContextImpl) processServiceUpdates(services []*rest_model.Service
 
 			return newValue
 		})
+
+		if isChange {
+			context.Emit(EventServiceChanged, s)
+		} else {
+			context.Emit(EventServiceAdded, s)
+		}
 
 		if context.options.OnServiceUpdate != nil {
 			if isChange {
@@ -434,6 +687,55 @@ func (context *ContextImpl) GetCurrentIdentity() (*rest_model.IdentityDetail, er
 	return context.CtrlClt.GetCurrentIdentity()
 }
 
+func (context *ContextImpl) setUnauthenticated() {
+	willEmit := context.CtrlClt.CurrentAPISessionDetail != nil
+	prevApiSession := context.CtrlClt.CurrentAPISessionDetail
+
+	context.CtrlClt.CurrentAPISessionDetail = nil
+	context.CtrlClt.ApiSessionCertificate = nil
+
+	context.CloseAllEdgeRouterConns()
+
+	if willEmit {
+		context.Emit(EventAuthenticationStateUnauthenticated, prevApiSession)
+	}
+}
+
+func (context *ContextImpl) authenticate() error {
+	logrus.Debug("attempting to authenticate")
+	context.services = cmap.New[*rest_model.ServiceDetail]()
+	context.sessions = cmap.New[*rest_model.SessionDetail]()
+	context.intercepts = cmap.New[*edge.InterceptV1Config]()
+
+	context.setUnauthenticated()
+
+	apiSession, err := context.CtrlClt.Authenticate()
+
+	if err != nil {
+		return err
+	}
+
+	if len(apiSession.AuthQueries) != 0 {
+		context.Emit(EventAuthenticationStatePartial, apiSession)
+		for _, authQuery := range apiSession.AuthQueries {
+			if err := context.handleAuthQuery(authQuery); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return context.onFullAuth()
+}
+
+func (context *ContextImpl) Reauthenticate() error {
+	context.CtrlClt.CurrentAPISessionDetail = nil
+	context.CtrlClt.ApiSessionCertificate = nil
+
+	return context.authenticate()
+}
+
 func (context *ContextImpl) Authenticate() error {
 	if context.CtrlClt.GetCurrentApiSession() != nil {
 		logrus.Debug("previous apiSession detected, checking if valid")
@@ -445,32 +747,23 @@ func (context *ContextImpl) Authenticate() error {
 		}
 	}
 
-	logrus.Debug("attempting to authenticate")
-	context.services = cmap.New[*rest_model.ServiceDetail]()
-	context.sessions = cmap.New[*rest_model.SessionDetail]()
-	context.intercepts = cmap.New[*edge.InterceptV1Config]()
+	return context.authenticate()
+}
 
-	apiSession, err := context.CtrlClt.Authenticate()
-
-	if err != nil {
-		return err
-	}
-
-	if len(apiSession.AuthQueries) != 0 {
-		for _, authQuery := range apiSession.AuthQueries {
-			if err := context.handleAuthQuery(authQuery); err != nil {
-				return err
+func (context *ContextImpl) CloseAllEdgeRouterConns() {
+	for entry := range context.routerConnections.IterBuffered() {
+		key, val := entry.Key, entry.Val
+		if !val.IsClosed() {
+			if err := val.Close(); err != nil {
+				pfxlog.Logger().WithError(err).Error("error while closing edge router connection")
 			}
 		}
+
+		context.routerConnections.Remove(key)
 	}
+}
 
-	// router connections are establishing using the api token. If we re-authenticate we must re-establish connections
-	for entry := range context.routerConnections.IterBuffered() {
-		_ = entry.Val.Close()
-	}
-
-	context.routerConnections = cmap.New[edge.RouterConn]()
-
+func (context *ContextImpl) onFullAuth() error {
 	var doOnceErr error
 	context.firstAuthOnce.Do(func() {
 		if context.options.OnContextReady != nil {
@@ -483,29 +776,53 @@ func (context *ContextImpl) Authenticate() error {
 		}
 
 		context.metrics = metrics.NewRegistry(context.CtrlClt.GetCurrentApiSession().Identity.Name, metricsTags)
-
-		// get services
-		if err := context.RefreshServices(); err != nil {
-			doOnceErr = err
-		}
 	})
+
+	context.Emit(EventAuthenticationStateFull, context.CtrlClt.GetCurrentApiSession())
+
+	// get services
+	if err := context.RefreshServices(); err != nil {
+		doOnceErr = err
+	}
 
 	return doOnceErr
 }
 
-func (context *ContextImpl) AddZitiMfaHandler(handler func(query *rest_model.AuthQueryDetail, resp func(code string) error) error) {
+func (context *ContextImpl) AddZitiMfaHandler(handler func(query *rest_model.AuthQueryDetail, response MfaCodeResponse) error) {
 	context.authQueryHandlers[string(rest_model.MfaProvidersZiti)] = handler
 }
 
+func (context *ContextImpl) authenticateMfa(code string) error {
+	if err := context.CtrlClt.AuthenticateMFA(code); err != nil {
+		return err
+	}
+
+	if _, err := context.CtrlClt.Refresh(); err != nil {
+		return err
+	}
+
+	if context.CtrlClt.CurrentAPISessionDetail != nil && len(context.CtrlClt.CurrentAPISessionDetail.AuthQueries) == 0 {
+		return context.onFullAuth()
+	}
+
+	return nil
+}
+
 func (context *ContextImpl) handleAuthQuery(authQuery *rest_model.AuthQueryDetail) error {
+	context.Emit(EventAuthQuery, authQuery)
+
 	if *authQuery.Provider == rest_model.MfaProvidersZiti {
 		handler := context.authQueryHandlers[string(rest_model.MfaProvidersZiti)]
 
+		context.Emit(EventMfaTotpCode, authQuery, MfaCodeResponse(context.authenticateMfa))
+
 		if handler == nil {
-			return fmt.Errorf("no handler registered for: %v", authQuery.Provider)
+			pfxlog.Logger().Errorf("no callback handler registered for provider: %v, event will still be emitted", *authQuery.Provider)
+		} else {
+			return handler(authQuery, context.authenticateMfa)
 		}
 
-		return handler(authQuery, context.CtrlClt.AuthenticateMFA)
+		return nil
 	}
 
 	return fmt.Errorf("unsupported MFA provider: %v", authQuery.Provider)
@@ -836,6 +1153,8 @@ func (context *ContextImpl) connectEdgeRouter(routerName, ingressUrl string, ret
 
 	logger.Debugf("connected to %s", ingressUrl)
 
+	context.Emit(EventRouterConnected, edgeConn.Key())
+
 	useConn := context.routerConnections.Upsert(ingressUrl, edgeConn,
 		func(exist bool, oldV edge.RouterConn, newV edge.RouterConn) edge.RouterConn {
 			if exist { // use the routerConnection already in the map, close new one
@@ -1034,16 +1353,9 @@ func (context *ContextImpl) deleteServiceSessions(svcId string) {
 func (context *ContextImpl) Close() {
 	if context.closed.CompareAndSwap(false, true) {
 		close(context.closeNotify)
-		// remove any closed connections
-		for entry := range context.routerConnections.IterBuffered() {
-			key, val := entry.Key, entry.Val
-			if !val.IsClosed() {
-				if err := val.Close(); err != nil {
-					pfxlog.Logger().WithError(err).Error("error while closing connection")
-				}
-			}
-			context.routerConnections.Remove(key)
-		}
+
+		context.CloseAllEdgeRouterConns()
+
 	}
 }
 

--- a/ziti/ziti_test.go
+++ b/ziti/ziti_test.go
@@ -2,6 +2,7 @@ package ziti
 
 import (
 	"fmt"
+	"github.com/kataras/go-events"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/openziti/sdk-golang/ziti/edge"
 	"github.com/openziti/sdk-golang/ziti/edge/posture"
@@ -35,6 +36,7 @@ func Test_contextImpl_processServiceUpdates(t *testing.T) {
 		CtrlClt: &CtrlClient{
 			PostureCache: posture.NewCache(nil, closeNotify),
 		},
+		EventEmmiter: events.New(),
 	}
 
 	var services []*rest_model.ServiceDetail
@@ -182,6 +184,7 @@ func Test_AddressMatch(t *testing.T) {
 		CtrlClt: &CtrlClient{
 			PostureCache: posture.NewCache(nil, nil),
 		},
+		EventEmmiter: events.New(),
 	}
 	ctx.processServiceUpdates(services)
 


### PR DESCRIPTION
Example of using the new events.

```
ztx, err := ziti.NewContext(cfg)

serviceAddedChan := make(chan *rest_model.ServiceDetail, 1)

serviceAddedRemover := ztx.Events().AddServiceAddedListener(func(detail *rest_model.ServiceDetail) {
	serviceAddedChan <- detail
})
```

Tests are in the `edge` repo...as there is a circular dependency trying to run controllers for integration tests here. See draft PR here: https://github.com/openziti/edge/pull/1501