### PR TITLE
use prefixed URLs from enrollment JWTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# Release 0.20.59
+
+- SDK context's will now use the properly prefixed Edge Client API Path for enrollment configurations. Previous versions
+  relied upon legacy path support in scenarios where Ziti Context configurations were generated from an enrollment JWT.
+- Added `edge_apis.ClientUrl(hostname string)` and `edge_apis.ManagementUrl(hostname string)` to convert hostnames
+  to fully prefixed API URls.
+
+# Release 0.20.52 - 0.20.58
+
+- minor bug fixes
+- dependency updates
+
+
+# Release 0.20.51
+
+## WHat's New
+
+* Edge Router Filter Options - now possible to filter Edge Routers based on connection URL
+
+## Edge Router Filter Options
+
+When creating Ziti SDK Context instances, the options argument can now contain an `EdgeRouterUrlFilter` function
+that takes in a string URL and returns a boolean to determine if the context will use that connection string
+to connect to the Edge Router. This is useful when operating in restricted environments, GoLang WASM, where
+some connection methods are no allowed (i.e. tcp/tls vs ws/wss).
+
+```go
+	cfg := &ziti.Config{
+		ZtAPI:       "https://localhost:1280/edge/client/v1",
+		Credentials: credentials,
+	}
+	ctx, err := ziti.NewContextWithOpts(cfg, &ziti.Options{
+		EdgeRouterUrlFilter: func(addr string) bool {
+			return strings.HasPrefix(addr,"wss")
+		},
+	})
+```
+
+
+
 # Release 0.20.50
 
 ## What's New

--- a/edge-apis/urls.go
+++ b/edge-apis/urls.go
@@ -1,0 +1,44 @@
+/*
+	Copyright 2019 NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package edge_apis
+
+import "strings"
+
+const (
+	ClientApiPath     = "/edge/client/v1"
+	ManagementApiPath = "/edge/management/v1"
+)
+
+// ClientUrl returns a URL with the given hostname in the format of `https://<hostname>/edge/management/v1`.
+// The hostname provided may include a port.
+func ClientUrl(hostname string) string {
+	if !strings.Contains(hostname, "://") {
+		hostname = "https://" + hostname
+	}
+
+	return hostname + ClientApiPath
+}
+
+// ManagementUrl returns a URL with the given hostname in the format of `https://<hostname>/edge/management/v1`.
+// The hostname provided may include a port.
+func ManagementUrl(hostname string) string {
+	if !strings.Contains(hostname, "://") {
+		hostname = "https://" + hostname
+	}
+
+	return hostname + ManagementApiPath
+}

--- a/ziti/enroll/enroll.go
+++ b/ziti/enroll/enroll.go
@@ -163,7 +163,7 @@ func Enroll(enFlags EnrollmentFlags) (*ziti.Config, error) {
 	var err error
 
 	cfg := &ziti.Config{
-		ZtAPI: enFlags.Token.Issuer,
+		ZtAPI: edge_apis.ClientUrl(enFlags.Token.Issuer),
 	}
 
 	if strings.TrimSpace(enFlags.KeyFile) != "" {


### PR DESCRIPTION
- adds utility functions to convert hostnames/partial URLs to full urls with paths for edge management/client APIs