### PR TITLE
Fix AddJWT to init c.Headers if still nil.

### DIFF
--- a/edge-apis/credentials.go
+++ b/edge-apis/credentials.go
@@ -101,6 +101,9 @@ type BaseCredentials struct {
 // AddJWT adds additional JWTs to the credentials. Used to satisfy secondary authentication/MFA requirements. The
 // provided token should be the base64 encoded version of the token.
 func (c *BaseCredentials) AddJWT(token string) {
+	if c.Headers == nil {
+		c.Headers = &http.Header{}
+	}
 	c.Headers.Add("authorization", "Bearer "+token)
 }
 

--- a/edge-apis/credentials.go
+++ b/edge-apis/credentials.go
@@ -98,15 +98,6 @@ type BaseCredentials struct {
 	CaPool *x509.CertPool
 }
 
-// AddJWT adds additional JWTs to the credentials. Used to satisfy secondary authentication/MFA requirements. The
-// provided token should be the base64 encoded version of the token.
-func (c *BaseCredentials) AddJWT(token string) {
-	if c.Headers == nil {
-		c.Headers = &http.Header{}
-	}
-	c.Headers.Add("authorization", "Bearer "+token)
-}
-
 // Payload will produce the object used to construct the body of an authentication requests. The base version
 // sets shared information available in BaseCredentials.
 func (c *BaseCredentials) Payload() *rest_model.Authenticate {
@@ -138,6 +129,12 @@ func (c *BaseCredentials) AddHeader(key, value string) {
 		c.Headers = &http.Header{}
 	}
 	c.Headers.Add(key, value)
+}
+
+// AddJWT adds additional JWTs to the credentials. Used to satisfy secondary authentication/MFA requirements. The
+// provided token should be the base64 encoded version of the token. Convenience function for AddHeader.
+func (c *BaseCredentials) AddJWT(token string) {
+	c.AddHeader("Authorization", "Bearer "+token)
 }
 
 // AuthenticateRequest provides a base implementation to authenticate an outgoing request. This is provided here


### PR DESCRIPTION
Currently, a call to AddJWT will cause a SegFault if attempted to be run on Credentials before Credentials.Headers has been initialized. This patch ensures that Headers is initialized if found to be nil when AddJWT is called.