### PR TITLE
properly concatenate base url and path

### DIFF
--- a/edge-apis/urls.go
+++ b/edge-apis/urls.go
@@ -30,6 +30,9 @@ func ClientUrl(hostname string) string {
 		hostname = "https://" + hostname
 	}
 
+	if strings.HasSuffix(hostname, "/") {
+		return strings.Trim(hostname, "/") + ClientApiPath
+	}
 	return hostname + ClientApiPath
 }
 

--- a/edge-apis/urls.go
+++ b/edge-apis/urls.go
@@ -28,22 +28,19 @@ const (
 // ClientUrl returns a URL with the given hostname in the format of `https://<hostname>/edge/management/v1`.
 // The hostname provided may include a port.
 func ClientUrl(hostname string) string {
-	if !strings.Contains(hostname, "://") {
-		hostname = "https://" + hostname
-	}
 	return concat(hostname, ClientApiPath)
 }
 
 // ManagementUrl returns a URL with the given hostname in the format of `https://<hostname>/edge/management/v1`.
 // The hostname provided may include a port.
 func ManagementUrl(hostname string) string {
-	if !strings.Contains(hostname, "://") {
-		hostname = "https://" + hostname
-	}
 	return concat(hostname, ManagementApiPath)
 }
 
 func concat(base, path string) string {
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
 	if strings.HasSuffix(base, "/") {
 		return strings.Trim(base, "/") + path
 	}

--- a/edge-apis/urls.go
+++ b/edge-apis/urls.go
@@ -16,7 +16,9 @@
 
 package edge_apis
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	ClientApiPath     = "/edge/client/v1"
@@ -29,11 +31,7 @@ func ClientUrl(hostname string) string {
 	if !strings.Contains(hostname, "://") {
 		hostname = "https://" + hostname
 	}
-
-	if strings.HasSuffix(hostname, "/") {
-		return strings.Trim(hostname, "/") + ClientApiPath
-	}
-	return hostname + ClientApiPath
+	return concat(hostname, ClientApiPath)
 }
 
 // ManagementUrl returns a URL with the given hostname in the format of `https://<hostname>/edge/management/v1`.
@@ -42,6 +40,12 @@ func ManagementUrl(hostname string) string {
 	if !strings.Contains(hostname, "://") {
 		hostname = "https://" + hostname
 	}
+	return concat(hostname, ManagementApiPath)
+}
 
-	return hostname + ManagementApiPath
+func concat(base, path string) string {
+	if strings.HasSuffix(base, "/") {
+		return strings.Trim(base, "/") + path
+	}
+	return base + path
 }


### PR DESCRIPTION
closes #487 

If the issuer in the jwt ends with a slash such as: `  "iss": "https://localhost:11280/",` the url to fetch the CA bundle would get concatenated with a doubled slash:

```
https://localhost:11280//edge/client/v1
```
