### PR TITLE
Issue 489 log when no match

### DIFF
--- a/ziti/dialer.go
+++ b/ziti/dialer.go
@@ -3,6 +3,7 @@ package ziti
 import (
 	"context"
 	"fmt"
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/edge-api/rest_model"
 	"math"
 	"net"
@@ -85,6 +86,10 @@ func (dialer *dialer) Dial(network, address string) (net.Conn, error) {
 			}
 		}
 	})
+
+	if best == math.MaxInt && dialer.fallback == nil {
+		pfxlog.Logger().Errorf("attempted to dial %s but no service with matching intercept found", address)
+	}
 
 	if ztx != nil && service != nil {
 		return ztx.(*ContextImpl).dialServiceFromAddr(*service.Name, network, host, uint16(port))

--- a/ziti/dialer.go
+++ b/ziti/dialer.go
@@ -88,7 +88,7 @@ func (dialer *dialer) Dial(network, address string) (net.Conn, error) {
 	})
 
 	if best == math.MaxInt && dialer.fallback == nil {
-		pfxlog.Logger().Errorf("attempted to dial %s but no service with matching intercept found", address)
+		pfxlog.Logger().Warnf("attempted to dial %s but no service with matching intercept found", address)
 	}
 
 	if ztx != nil && service != nil {


### PR DESCRIPTION
closes #489 

Adds a log statement giving you a hint that your identity can't dial the requested address