### PR TITLE
adds a temporary feature flag to enable OIDC (HA) based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Relase 0.23.1
+
+## What's New
+
+* `EnableHa` Feature Toggle
+
+### `EnableHa` Feature Toggle
+
+Configuration structs and files used to initialize SDK contexts now supports a boolean field named `EnableHa` (struct) 
+and `enableHa` (JSON configuration) that enables OIDC HA authentication models. Existing implementations should not
+have to make any adjustments as it will default to `false`/disabled. HA is experimental only and should not be used
+unless one expects to test HA deployments.
+
 # Release 0.23.0
 
 ## What's New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Relase 0.23.1
+# Relase 0.23.2
 
 ## What's New
 

--- a/edge-apis/clients.go
+++ b/edge-apis/clients.go
@@ -34,6 +34,10 @@ type ApiType interface {
 	ZitiEdgeManagement | ZitiEdgeClient
 }
 
+type OidcEnabledApi interface {
+	SetUseOidc(use bool)
+}
+
 // BaseClient implements the Client interface specifically for the types specified in the ApiType constraint. It
 // provides shared functionality that all ApiType types require.
 type BaseClient[A ApiType] struct {
@@ -52,6 +56,12 @@ func (self *BaseClient[A]) GetCurrentApiSession() ApiSession {
 	}
 
 	return *ptr
+}
+
+func (self *BaseClient[A]) SetUseOidc(use bool) {
+	v := any(self.API)
+	apiType := v.(OidcEnabledApi)
+	apiType.SetUseOidc(use)
 }
 
 // Authenticate will attempt to use the provided credentials to authenticate via the underlying ApiType. On success

--- a/ziti/config.go
+++ b/ziti/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	//The Credentials field is used to authenticate with the Edge Client API. If the ID field is set, it will be used
 	//to populate this field with credentials.
 	Credentials apis.Credentials `json:"-"`
+
+	//EnableHa will signal to the SDK to query and use OIDC authentication which is required for HA controller setups.
+	//This is a temporary feature flag that will be removed and "default to true" at a later date.
+	EnableHa bool `json:"enableHa"`
 }
 
 // NewConfig will create a new Config object from a provided Ziti Edge Client API URL and identity configuration.

--- a/ziti/contexts.go
+++ b/ziti/contexts.go
@@ -143,6 +143,7 @@ func NewContextWithOpts(cfg *Config, options *Options) (Context, error) {
 		ConfigTypes: cfg.ConfigTypes,
 	}
 
+	newContext.CtrlClt.ClientApiClient.SetUseOidc(cfg.EnableHa)
 	newContext.CtrlClt.PostureCache = posture.NewCache(newContext.CtrlClt, newContext.closeNotify)
 
 	return newContext, nil


### PR DESCRIPTION
- existing implementations and configuration files will not have this value set and will default to false
- the default, false, state is to use legacy auth