### PR TITLE
adds OIDC dynamic SDK check flag, fix ptr ref to unauthed handler

### DIFF
--- a/edge-apis/clients.go
+++ b/edge-apis/clients.go
@@ -35,7 +35,13 @@ type ApiType interface {
 }
 
 type OidcEnabledApi interface {
+	// SetUseOidc forces an API Client to operate in OIDC mode (true) or legacy mode (false). The state of the controller
+	// is ignored and dynamic enable/disable of OIDC support is suspended.
 	SetUseOidc(use bool)
+
+	// SetAllowOidcDynamicallyEnabled sets whether clients will check the controller for OIDC support or not. If supported
+	// OIDC is favored over legacy authentication.
+	SetAllowOidcDynamicallyEnabled(allow bool)
 }
 
 // BaseClient implements the Client interface specifically for the types specified in the ApiType constraint. It
@@ -62,6 +68,12 @@ func (self *BaseClient[A]) SetUseOidc(use bool) {
 	v := any(self.API)
 	apiType := v.(OidcEnabledApi)
 	apiType.SetUseOidc(use)
+}
+
+func (self *BaseClient[A]) SetAllowOidcDynamicallyEnabled(allow bool) {
+	v := any(self.API)
+	apiType := v.(OidcEnabledApi)
+	apiType.SetAllowOidcDynamicallyEnabled(allow)
 }
 
 // Authenticate will attempt to use the provided credentials to authenticate via the underlying ApiType. On success

--- a/ziti/contexts.go
+++ b/ziti/contexts.go
@@ -143,7 +143,7 @@ func NewContextWithOpts(cfg *Config, options *Options) (Context, error) {
 		ConfigTypes: cfg.ConfigTypes,
 	}
 
-	newContext.CtrlClt.ClientApiClient.SetUseOidc(cfg.EnableHa)
+	newContext.CtrlClt.ClientApiClient.SetAllowOidcDynamicallyEnabled(cfg.EnableHa)
 	newContext.CtrlClt.PostureCache = posture.NewCache(newContext.CtrlClt, newContext.closeNotify)
 
 	return newContext, nil


### PR DESCRIPTION
- Internal API clients now support a flag to enable or disable OIDC support checks in addition to forcefully setting the OIDC support state.
- The unauthenticated SDK event will no longer pass a double pointer to handlers