### PR TITLE
fix refresh tight loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Release notes 0.23.38
+
+## Issues Fixed and Dependency Updates
+
+* github.com/openziti/sdk-golang: [v0.23.37 -> v0.23.38](https://github.com/openziti/sdk-golang/compare/v0.23.37...v0.23.38)
+    * [Issue #573](https://github.com/openziti/sdk-golang/issues/573) - api session refresh spins in a tight loop if there is no current api session
+
 # Release notes 0.23.37
 
 ## Issues Fixed and Dependency Updates

--- a/ziti/sdkinfo/build_info.go
+++ b/ziti/sdkinfo/build_info.go
@@ -20,5 +20,5 @@
 package sdkinfo
 
 const (
-	Version   = "v0.23.37"
+	Version   = "v0.23.38"
 )

--- a/ziti/ziti.go
+++ b/ziti/ziti.go
@@ -796,7 +796,11 @@ func (context *ContextImpl) runRefreshes() {
 			apiSession := context.CtrlClt.GetCurrentApiSession()
 
 			if apiSession == nil {
-				pfxlog.Logger().Warn("could not refresh api session, current api session is nil")
+				pfxlog.Logger().Warn("could not refresh api session, current api session is nil, authenticating")
+				if err := context.Authenticate(); err != nil {
+					pfxlog.Logger().WithError(err).Error("failed to authenticate")
+				}
+				refreshAt = time.Now().Add(5 * time.Second)
 				continue
 			}
 


### PR DESCRIPTION
- **Don't spin in tight loop if api session isn't set. Fixes #573**
- **Update changelog**
