### PR TITLE
allow overriding the necessary settings to work with zitadel and others

### DIFF
--- a/example/jwtchat/jwtchat-client/client.go
+++ b/example/jwtchat/jwtchat-client/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"github.com/Jeffail/gabs"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
@@ -14,16 +15,37 @@ import (
 )
 
 func main() {
+	openzitiURL := flag.String("openziti-url", "https://localhost:1280", "URL of the OpenZiti service")
+	idpTokenUrl := flag.String("idp-token-url", "http://localhost:9998/oauth/token", "URL of the Identity Provider")
+	fmt.Printf("hi there\n\n")
+	fmt.Println(*idpTokenUrl)
+	fmt.Printf("hi there\n\n")
+	clientID := flag.String("client-id", "cid2", "Client ID for authentication")
+	clientSecret := flag.String("client-secret", "cid2secret", "Client Secret for authentication")
+	grantType := flag.String("grant-type", "client_credentials", "The grant type to use")
+	scope := flag.String("scope", "openid", "The scope to use")
+
+	// Parse flags
+	flag.Parse()
+
+	// Print values
+	fmt.Println("OpenZiti URL\t:", *openzitiURL)
+	fmt.Println("IDP URL\t\t:", *idpTokenUrl)
+	fmt.Println("Client ID\t:", *clientID)
+	fmt.Println("Client Secret\t:", *clientSecret)
+	fmt.Println("Grant Type\t:", *grantType)
+	fmt.Println("Scope\t\t:", *scope)
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 
-	jwtToken, err := getExternalJWT()
+	jwtToken, err := getExternalJWT(*clientID, *clientSecret, *grantType, *scope, *idpTokenUrl)
 
 	if err != nil {
 		panic(err)
 	}
 
-	caPool, err := ziti.GetControllerWellKnownCaPool("https://localhost:1280")
+	caPool, err := ziti.GetControllerWellKnownCaPool(*openzitiURL)
 
 	if err != nil {
 		panic(err)
@@ -33,7 +55,7 @@ func main() {
 	credentials.CaPool = caPool
 
 	cfg := &ziti.Config{
-		ZtAPI:       "https://localhost:1280/edge/client/v1",
+		ZtAPI: *openzitiURL + "/edge/client/v1",
 		Credentials: credentials,
 	}
 	ctx, err := ziti.NewContext(cfg)
@@ -115,32 +137,32 @@ func main() {
 }
 
 // getExternalJWT will use Open ID Connect's client credentials flow to obtain a JWT from the jwtchat-idp executable.
-func getExternalJWT() (string, error) {
+func getExternalJWT(clientId string, clientSecret string, grantType string, scope string, idpTokenUrl string) (string, error) {
 	resp, err := resty.R().SetFormData(map[string]string{
-		"client_secret": "cid1secret",
-		"client_id":     "cid1",
-		"grant_type":    "client_credentials",
-		"scope":         "openid",
-	}).Post("http://localhost:9998/oauth/token")
+		"client_secret": clientSecret,
+		"client_id":     clientId,
+		"grant_type":    grantType,
+		"scope":         scope,
+	}).Post(idpTokenUrl)
+
+	if err != nil {
+		return "", err
+	}
+	json := resp.Body()
+	jsonContainer, err := gabs.ParseJSON(json)
 
 	if err != nil {
 		return "", err
 	}
 
-	jsonContainer, err := gabs.ParseJSON(resp.Body())
-
-	if err != nil {
-		return "", err
+	tokenName := "access_token"
+	if !jsonContainer.ExistsP(tokenName) {
+		return "", errors.New("no " + tokenName + " property found")
 	}
 
-	if !jsonContainer.ExistsP("access_token") {
-		return "", errors.New("no access_token property found")
-	}
-
-	token, ok := jsonContainer.Path("access_token").Data().(string)
-
+	token, ok := jsonContainer.Path(tokenName).Data().(string)
 	if !ok {
-		return "", errors.New("access_token was not a valid JSON string")
+		return "", errors.New(tokenName + " was not a valid JSON string")
 	}
 
 	return token, nil

--- a/example/jwtchat/jwtchat-server/server.go
+++ b/example/jwtchat/jwtchat-server/server.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"github.com/Jeffail/gabs"
 	edge_apis "github.com/openziti/sdk-golang/edge-apis"
-
 	"github.com/openziti/sdk-golang/ziti"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -15,16 +15,34 @@ import (
 )
 
 func main() {
+	openzitiURL := flag.String("openziti-url", "https://localhost:1280", "URL of the OpenZiti service")
+	idpTokenUrl := flag.String("idp-token-url", "http://localhost:9998/oauth/token", "URL of the Identity Provider")
+	clientID := flag.String("client-id", "cid2", "Client ID for authentication")
+	clientSecret := flag.String("client-secret", "cid2secret", "Client Secret for authentication")
+	grantType := flag.String("grant-type", "client_credentials", "The grant type to use")
+	scope := flag.String("scope", "openid", "The scope to use")
+
+	// Parse flags
+	flag.Parse()
+
+	// Print values
+	fmt.Println("OpenZiti URL\t:", *openzitiURL)
+	fmt.Println("IDP URL\t\t:", *idpTokenUrl)
+	fmt.Println("Client ID\t:", *clientID)
+	fmt.Println("Client Secret\t:", *clientSecret)
+	fmt.Println("Grant Type\t:", *grantType)
+	fmt.Println("Scope\t\t:", *scope)
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 
-	jwtToken, err := getExternalJWT()
+	jwtToken, err := getExternalJWT(*clientID, *clientSecret, *grantType, *scope, *idpTokenUrl)
 
 	if err != nil {
 		panic(err)
 	}
 
-	caPool, err := ziti.GetControllerWellKnownCaPool("https://localhost:1280")
+	caPool, err := ziti.GetControllerWellKnownCaPool(*openzitiURL)
 
 	if err != nil {
 		panic(err)
@@ -34,7 +52,7 @@ func main() {
 	authenticator.CaPool = caPool
 
 	cfg := &ziti.Config{
-		ZtAPI:       "https://localhost:1280/edge/client/v1",
+		ZtAPI: *openzitiURL + "/edge/client/v1",
 		Credentials: authenticator,
 	}
 	ctx, err := ziti.NewContext(cfg)
@@ -131,32 +149,32 @@ func main() {
 }
 
 // getExternalJWT will use Open ID Connect's client credentials flow to obtain a JWT from the jwtchat-idp executable.
-func getExternalJWT() (string, error) {
+func getExternalJWT(clientId string, clientSecret string, grantType string, scope string, idpTokenUrl string) (string, error) {
 	resp, err := resty.R().SetFormData(map[string]string{
-		"client_secret": "cid2secret",
-		"client_id":     "cid2",
-		"grant_type":    "client_credentials",
-		"scope":         "openid",
-	}).Post("http://localhost:9998/oauth/token")
+		"client_secret": clientSecret,
+		"client_id":     clientId,
+		"grant_type":    grantType,
+		"scope":         scope,
+	}).Post(idpTokenUrl)
+
+	if err != nil {
+		return "", err
+	}
+	json := resp.Body()
+	jsonContainer, err := gabs.ParseJSON(json)
 
 	if err != nil {
 		return "", err
 	}
 
-	jsonContainer, err := gabs.ParseJSON(resp.Body())
-
-	if err != nil {
-		return "", err
+	tokenName := "access_token"
+	if !jsonContainer.ExistsP(tokenName) {
+		return "", errors.New("no " + tokenName + " property found")
 	}
 
-	if !jsonContainer.ExistsP("access_token") {
-		return "", errors.New("no access_token property found")
-	}
-
-	token, ok := jsonContainer.Path("access_token").Data().(string)
-
+	token, ok := jsonContainer.Path(tokenName).Data().(string)
 	if !ok {
-		return "", errors.New("access_token was not a valid JSON string")
+		return "", errors.New(tokenName + " was not a valid JSON string")
 	}
 
 	return token, nil


### PR DESCRIPTION
These changes allow a user to supply the various pieces for acquiring the JWT from another IdP such as zitadel. All the defaults are the same as the previous example and README and `go run jwtchat-server/server.go` and `go run jwtchat-client/client.go` still successfully run the example

cid2 (the server):
```
go run jwtchat-server/server.go \
	--openziti-url="https://localhost:12345" \
	--idp-token-url="http://my.zitadel.server:8080/oauth/v2/token" \
	--client-id="cid2" \
	--client-secret="cid2_secret" \
	--scope="openid urn:zitadel:iam:org:project:id:openziti:aud"
```

cid1 (the client):
```
go run jwtchat-client/client.go \
	--openziti-url="https://localhost:12345" \
	--idp-token-url="http://my.zitadel.server:8080/oauth/v2/token" \
	--client-id="cid1" \
	--client-secret="cid1_secret" \
	--scope="openid urn:zitadel:iam:org:project:id:openziti:aud"
```