### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/zitadel/oidc/v2 v2.12.2
 	go.mozilla.org/pkcs7 v0.9.0
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/sys v0.31.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/ziti/edge/types.go
+++ b/ziti/edge/types.go
@@ -6,8 +6,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/openziti/edge-api/rest_model"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 	"net"
+	"slices"
 	"strings"
 )
 


### PR DESCRIPTION
These experimental packages are now available in the Go standard library.

1. `golang.org/x/exp/slices` -> `slices` (https://go.dev/doc/go1.21#slices)
2. `golang.org/x/exp/rand` -> `math/rand/v2` (https://go.dev/doc/go1.22#math_rand_v2)

`golang.org/x/exp/rand` has been deprecated and scheduled to be deleted.

Reference: https://github.com/golang/exp/commit/f9890c6ad9f380fd3cdb66a33843f522d4790e03