### PR TITLE
Adding router proxy support

### DIFF
--- a/ziti/config.go
+++ b/ziti/config.go
@@ -121,7 +121,8 @@ func NewConfigFromFile(confFile string) (*Config, error) {
 		// Parse the HTTPS_PROXY env (or https:// proxy setting) for this address
 		req := &http.Request{URL: &url.URL{Host: addr}}
 		proxyURL, errProxy := http.ProxyFromEnvironment(req)
-		pfxlog.Logger().Infof("!!!!!!!!url: %s, proxyURL: %v, errProxy: %v", addr, proxyURL, errProxy)
+		val := os.Getenv("HTTPS_PROXY") // for debugging purposes
+		pfxlog.Logger().Infof("!!!!!!!!val: %s, url: %s, proxyURL: %v, errProxy: %v", val, addr, proxyURL, errProxy)
 		if proxyURL == nil {
 			return nil // no proxy
 		}

--- a/ziti/config.go
+++ b/ziti/config.go
@@ -136,7 +136,7 @@ func routerProxyFromEnvironment(addr string) *transport.ProxyConfiguration {
 	// Create a request with the address to parse
 	parsedURL, errParse := parseTLS(addr)
 	if errParse != nil {
-		pfxlog.Logger().Infof("Could not parse URL. Error: %s", errParse.Error())
+		pfxlog.Logger().Warnf("Could not parse URL. Error: %s", errParse.Error())
 		return nil
 	}
 	req := &http.Request{URL: parsedURL}
@@ -144,7 +144,7 @@ func routerProxyFromEnvironment(addr string) *transport.ProxyConfiguration {
 	// Parse the HTTPS_PROXY or HTTP_PROXY env for this address
 	proxyURL, errProxy := http.ProxyFromEnvironment(req)
 	if errProxy != nil {
-		pfxlog.Logger().Infof("Could not determine proxy from environment. Error: %s", errProxy.Error())
+		pfxlog.Logger().Warnf("Could not determine proxy from environment. Error: %s", errProxy.Error())
 		return nil
 	}
 	if proxyURL == nil {

--- a/ziti/config.go
+++ b/ziti/config.go
@@ -119,10 +119,15 @@ func NewConfigFromFile(confFile string) (*Config, error) {
 
 	c.RouterProxy = func(addr string) *transport.ProxyConfiguration {
 		// Parse the HTTPS_PROXY env (or https:// proxy setting) for this address
-		req := &http.Request{URL: &url.URL{Host: addr}}
+		parsedUrl, errParse := url.Parse(c.ZtAPI)
+		if errParse != nil {
+			pfxlog.Logger().Infof("!!!111!!!!!error: %s", errParse.Error())
+			return nil
+		}
+		req := &http.Request{URL: parsedUrl}
 		proxyURL, errProxy := http.ProxyFromEnvironment(req)
 		val := os.Getenv("HTTPS_PROXY") // for debugging purposes
-		pfxlog.Logger().Infof("!!!!!!!!val: %s, url: %s, proxyURL: %v, errProxy: %v", val, addr, proxyURL, errProxy)
+		pfxlog.Logger().Infof("!!!!!!!!val: %s, ZtAPI: %s, addr: %s, proxyURL: %v, errProxy: %v", val, c.ZtAPI, addr, proxyURL, errProxy)
 		if proxyURL == nil {
 			return nil // no proxy
 		}


### PR DESCRIPTION

# Add Router Proxy Configuration from Environment Variables

This PR adds two new functions to improve router connectivity options:

## Changes

1. **Added `routerProxyFromEnvironment` function**
   - Enables automatic proxy configuration for router connections based on environment variables
   - Uses `HTTPS_PROXY` or `HTTP_PROXY` environment variables to determine proxy settings
   - Automatically applied when loading configuration from file via `NewConfigFromFile()`

2. **Added `parseTLS(raw string)` helper function**
   - Supports router URLs with the format `tls:router.example.com:443`
   - Converts `tls:` scheme URLs to proper HTTPS URLs for processing
   - Enables more flexible router addressing options

## Use Cases

- Simplifies deployment in environments where direct connections are restricted and proxies are required
- Allows for consistent proxy configuration across applications using environment variables
- Supports more intuitive TLS connection specification with the `tls:` URL format

These changes maintain backward compatibility while adding flexibility for different network configurations.