### PR TITLE
Issue-913 - do not add authorization header for empty secondary jwt

### DIFF
--- a/edge-apis/credentials.go
+++ b/edge-apis/credentials.go
@@ -178,7 +178,9 @@ func (c *BaseCredentials) AuthenticateRequest(request runtime.ClientRequest, _ s
 		}
 	}
 
-	request.GetHeaderParams().Add("Authorization", "Bearer "+c.SecondaryJwt)
+	if c.SecondaryJwt != "" {
+		request.GetHeaderParams().Add("Authorization", "Bearer "+c.SecondaryJwt)
+	}
 
 	return nil
 }
@@ -197,7 +199,9 @@ func (c *BaseCredentials) ProcessRequest(request runtime.ClientRequest, _ strfmt
 		}
 	}
 
-	request.GetHeaderParams().Add("Authorization", "Bearer "+c.SecondaryJwt)
+	if c.SecondaryJwt != "" {
+		request.GetHeaderParams().Add("Authorization", "Bearer "+c.SecondaryJwt)
+	}
 
 	if len(errors) > 0 {
 		return network.MultipleErrors(errors)


### PR DESCRIPTION
Skip adding an empty `Bearer` authorization header if the secondary JWT is not provided during authentication.