### PR TITLE
fixes #932 preserves full API Session certificate chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Release notes 1.7.1
+
+## Issues Fixed and Dependency Updates
+
+* github.com/openziti/sdk-golang: [v1.7.0 -> v1.7.1](https://github.com/openziti/sdk-golang/compare/v1.7.0...v1.7.1)
+  * [Issue #932](https://github.com/openziti/sdk-golang/issues/932) - API Session Certificate chain is not preserved
+
 # Release notes 1.7.0
 
 ## Issues Fixed and Dependency Updates

--- a/ziti/client.go
+++ b/ziti/client.go
@@ -61,7 +61,7 @@ type CtrlClient struct {
 
 	ApiSessionCertificateDetail rest_model.CurrentAPISessionCertificateDetail
 	ApiSessionCsr               x509.CertificateRequest
-	ApiSessionCertificate       *x509.Certificate
+	ApiSessionCertificate       []*x509.Certificate
 	ApiSessionPrivateKey        *ecdsa.PrivateKey
 	ApiSessionCertInstance      string
 
@@ -309,7 +309,7 @@ func (self *CtrlClient) GetIdentity() (identity.Identity, error) {
 	}
 
 	rootCaPool := self.TlsAwareTransport.GetTlsClientConfig().RootCAs
-	return identity.NewClientTokenIdentityWithPool([]*x509.Certificate{self.ApiSessionCertificate}, self.ApiSessionPrivateKey, rootCaPool), nil
+	return identity.NewClientTokenIdentityWithPool(self.ApiSessionCertificate, self.ApiSessionPrivateKey, rootCaPool), nil
 }
 
 // EnsureApiSessionCertificate will create an ApiSessionCertificate if one does not already exist.
@@ -376,7 +376,7 @@ func (self *CtrlClient) NewApiSessionCertificate() error {
 
 	pfxlog.Logger().Infof("new API Session Certificate: %x", sha1.Sum(certs[0].Raw))
 
-	self.ApiSessionCertificate = certs[0]
+	self.ApiSessionCertificate = certs
 
 	return nil
 }

--- a/ziti/sdkinfo/build_info.go
+++ b/ziti/sdkinfo/build_info.go
@@ -20,5 +20,5 @@
 package sdkinfo
 
 const (
-	Version   = "v1.7.0"
+	Version   = "v1.7.1"
 )


### PR DESCRIPTION
- changes CtrlClient.ApiSessionCertificate from *x509.Certificate to []*x509.Certificate
- stores the full chain returned by the controller in NewApiSessionCertificate instead of only the leaf
- passes the chain directly to identity.NewClientTokenIdentityWithPool so intermediates are presented during TLS handshakes