### PR TITLE
Prep for channel v5: explicit receive handler registration, drop send priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Release notes 1.8.1
+
+## Issues Fixed and Dependency Updates
+
+* github.com/openziti/sdk-golang: [v1.8.0 -> v1.8.1](https://github.com/openziti/sdk-golang/compare/v1.8.0...v1.8.1)
+    * [Issue #941](https://github.com/openziti/sdk-golang/issues/941) - Prep for channel v5: explicit receive handler registration, drop send priorities
+
+
 # Release notes 1.8.0
 
 ## Issues Fixed and Dependency Updates

--- a/ziti/edge/msg_mux.go
+++ b/ziti/edge/msg_mux.go
@@ -264,19 +264,21 @@ type ConnMux[T any] interface {
 	//   mux.Add(conn)
 	GetNextId() uint32
 
-	// TypedReceiveHandler is an embedded interface
+	// ContentType returns the message content type this handler processes. Together
+	// with the embedded ReceiveHandler, it allows the ConnMux to be registered as a
+	// message handler with the underlying channel infrastructure, via
+	// binding.AddReceiveHandler(mux.ContentType(), mux).
+	ContentType() int32
+
+	// ReceiveHandler is an embedded interface
 	//
-	// TypedReceiveHandler provides typed message handling capabilities for the multiplexer.
-	// This allows the ConnMux to be registered as a message handler with the underlying
-	// channel infrastructure, enabling automatic message routing based on message types.
-	//
-	// The embedded interface typically includes methods like:
-	//   - ContentType() int32 - returns the message content type this handler processes
-	//   - HandleReceive(msg *channel.Message, ch channel.Channel) - processes typed messages
+	// ReceiveHandler provides message handling capabilities for the multiplexer,
+	// enabling automatic message routing based on message types:
+	//   - HandleReceive(msg *channel.Message, ch channel.Channel) - processes messages
 	//
 	// This integration allows the ConnMux to participate in the channel's message
 	// dispatch system while maintaining its connection multiplexing functionality.
-	channel.TypedReceiveHandler
+	channel.ReceiveHandler
 
 	// CloseHandler is an embedded interface
 	//

--- a/ziti/edge/network/conn.go
+++ b/ziti/edge/network/conn.go
@@ -901,7 +901,7 @@ func (conn *edgeConn) CompleteAcceptSuccess() error {
 
 			reply := edge.NewDialFailedMsg(conn.Id(), err.Error())
 			reply.ReplyTo(conn.acceptCompleteHandler.message)
-			if sendErr := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); sendErr != nil {
+			if sendErr := reply.WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); sendErr != nil {
 				logger.WithError(sendErr).Error("failed to send reply to dial request")
 			}
 		}
@@ -970,7 +970,7 @@ func (self *newConnHandler) dialFailed(err error) {
 	newConnLogger.WithError(err).Error("Failed to establish connection")
 	reply := edge.NewDialFailedMsg(self.conn.Id(), err.Error())
 	reply.ReplyTo(self.message)
-	if err := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendAndWaitForWire(self.conn.GetControlSender()); err != nil {
+	if err := reply.WithTimeout(5 * time.Second).SendAndWaitForWire(self.conn.GetControlSender()); err != nil {
 		logger.WithError(err).Error("Failed to send reply to dial request")
 	}
 }
@@ -990,7 +990,7 @@ func (self *newConnHandler) dialSucceeded() (error, bool) {
 	reply.ReplyTo(self.message)
 
 	if !self.routerProvidedConnId {
-		startMsg, err := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendForReply(self.conn.GetControlSender())
+		startMsg, err := reply.WithTimeout(5 * time.Second).SendForReply(self.conn.GetControlSender())
 		if err != nil {
 			logger.WithError(err).Error("failed to send reply to dial request")
 			return err, false
@@ -1001,7 +1001,7 @@ func (self *newConnHandler) dialSucceeded() (error, bool) {
 			self.edgeCh.close(true)
 			return errors.Errorf("failed to receive start after dial. got %v", startMsg), true
 		}
-	} else if err := reply.WithPriority(channel.Highest).WithTimeout(time.Second * 5).SendAndWaitForWire(self.conn.GetControlSender()); err != nil {
+	} else if err := reply.WithTimeout(time.Second * 5).SendAndWaitForWire(self.conn.GetControlSender()); err != nil {
 		logger.WithError(err).Error("failed to send reply to dial request")
 		return err, false
 	}

--- a/ziti/edge/network/factory.go
+++ b/ziti/edge/network/factory.go
@@ -107,7 +107,7 @@ func (conn *routerConn) BindChannel(binding channel.Binding) error {
 	binding.AddReceiveHandlerF(edge.ContentTypeInspectRequest, conn.mux.HandleReceive)
 
 	// Since data is the common message type, it gets to be dispatched directly
-	binding.AddTypedReceiveHandler(conn.mux)
+	binding.AddReceiveHandler(conn.mux.ContentType(), conn.mux)
 	binding.AddCloseHandler(conn.mux)
 	binding.AddCloseHandler(conn)
 

--- a/ziti/edge/network/hosting_conn.go
+++ b/ziti/edge/network/hosting_conn.go
@@ -279,7 +279,7 @@ func (conn *edgeHostConn) newChildConnection(message *channel.Message) {
 		logger.Warn("invalid token")
 		reply := edge.NewDialFailedMsg(conn.Id(), "invalid token")
 		reply.ReplyTo(message)
-		if err := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); err != nil {
+		if err := reply.WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); err != nil {
 			logger.WithError(err).Error("failed to send reply to dial request")
 		}
 		return
@@ -331,7 +331,7 @@ func (conn *edgeHostConn) newChildConnection(message *channel.Message) {
 
 		reply := edge.NewDialFailedMsg(conn.Id(), fmt.Sprintf("%s (%s)", description, err.Error()))
 		reply.ReplyTo(message)
-		if sendErr := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); sendErr != nil {
+		if sendErr := reply.WithTimeout(5 * time.Second).SendAndWaitForWire(conn.GetControlSender()); sendErr != nil {
 			logger.WithError(sendErr).Error("failed to send reply to dial request")
 		}
 	}

--- a/ziti/sdkinfo/build_info.go
+++ b/ziti/sdkinfo/build_info.go
@@ -20,5 +20,5 @@
 package sdkinfo
 
 const (
-	Version   = "v1.8.0"
+	Version   = "v1.8.1"
 )


### PR DESCRIPTION
Fixes #941

channel v5 removes the self-describing typed receive handler pattern and the per-message send priority API. Both have replacements that already exist in channel v4, so this makes the switch now to shrink the eventual v5 migration:

- typed receive handler registration moves to explicit content-type registration (`AddReceiveHandler(h.ContentType(), h)`), and `ConnMux` declares `ContentType()` plus an embedded `channel.ReceiveHandler` instead of embedding `channel.TypedReceiveHandler`
- `WithPriority` is dropped from control-channel sends; it was already a no-op on grouped channels, and on single-underlay channels the lost queue-jump is a latency-only effect that matches v5 behavior

No dependency change; this builds and tests on channel v4.3.11.