### PR TITLE
Skip GitHub release for pre-release and build-metadata tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+      - '!v*-*'   # exclude pre-release qualifiers (e.g. v2.0.0-pre)
+      - '!v*+*'   # exclude build metadata (e.g. v2.0.0+build)
 
 jobs:
   release:


### PR DESCRIPTION
## What

Restricts the `release-builds` workflow trigger so it no longer fires for tags containing a semver pre-release qualifier (`-`) or build metadata (`+`).

## Why

We want to start pushing `v2.0.0-pre` style tags so the SDK can be pulled into the ziti project, but tagging currently triggers a public GitHub release (marked as the latest, since `prerelease: false`). With this change, only plain release tags like `v2.0.0` produce a release; qualified tags are pushed for downstream consumption without publishing anything.