### PR TITLE
Add acceptance test for UPDB (username/password) auth

### DIFF
--- a/acceptance/harness/identity.go
+++ b/acceptance/harness/identity.go
@@ -28,6 +28,13 @@ import (
 	"testing"
 )
 
+// NamedEntity is anything with a controller name. The policy grant helpers take
+// it so they work across identity credential types (cert Identity, UpdbIdentity,
+// ...) without overloading per type.
+type NamedEntity interface {
+	Name() string
+}
+
 // Identity is a created-and-enrolled identity, usable to build an SDK context.
 type Identity struct {
 	name     string

--- a/acceptance/harness/services.go
+++ b/acceptance/harness/services.go
@@ -47,19 +47,19 @@ func (h *Harness) CreateService(t testing.TB, base string) *Service {
 // GrantDial creates a Dial service policy granting the identities access to svc.
 // Per the isolation contract the policy targets the named entities explicitly,
 // never #all or shared attributes.
-func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...*Identity) {
+func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...NamedEntity) {
 	t.Helper()
 	h.createServicePolicy(t, "Dial", svc, ids)
 }
 
 // GrantBind creates a Bind service policy granting the identities hosting access
 // to svc, targeting the named entities explicitly.
-func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...*Identity) {
+func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...NamedEntity) {
 	t.Helper()
 	h.createServicePolicy(t, "Bind", svc, ids)
 }
 
-func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []*Identity) {
+func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []NamedEntity) {
 	t.Helper()
 	name := uniqueName(t, strings.ToLower(polType))
 	h.Cli(t, "edge", "create", "service-policy", name, polType,
@@ -72,7 +72,7 @@ func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service
 
 // GrantRouterAccess creates an edge-router policy letting the identities use the
 // router, targeting both sides by name.
-func (h *Harness) GrantRouterAccess(t testing.TB, r *Router, ids ...*Identity) {
+func (h *Harness) GrantRouterAccess(t testing.TB, r *Router, ids ...NamedEntity) {
 	t.Helper()
 	name := uniqueName(t, "erp")
 	h.Cli(t, "edge", "create", "edge-router-policy", name,
@@ -96,7 +96,7 @@ func (h *Harness) GrantServiceRouterAccess(t testing.TB, svc *Service, r *Router
 	})
 }
 
-func identityRoles(ids []*Identity) string {
+func identityRoles(ids []NamedEntity) string {
 	roles := make([]string, len(ids))
 	for i, id := range ids {
 		roles[i] = "@" + id.Name()

--- a/acceptance/harness/updb.go
+++ b/acceptance/harness/updb.go
@@ -1,0 +1,115 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package harness
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	edgeApis "github.com/openziti/sdk-golang/v2/edge-apis"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// UpdbIdentity is a created identity that authenticates with a username/password
+// (UPDB) credential rather than a client certificate.
+type UpdbIdentity struct {
+	name     string
+	username string
+	password string
+}
+
+// Name returns the identity's unique name on the controller.
+func (i *UpdbIdentity) Name() string { return i.name }
+
+// Username returns the UPDB username (equal to the identity name).
+func (i *UpdbIdentity) Username() string { return i.username }
+
+// Password returns the UPDB password set during enrollment.
+func (i *UpdbIdentity) Password() string { return i.password }
+
+// CreateUpdbIdentity creates an identity with a UPDB enrollment and completes
+// that enrollment via the CLI, setting its password. The username equals the
+// identity name. roleAttributes, if given, are set for use in targeted policies.
+// The identity is uniquely named per the isolation contract, with best-effort
+// cleanup.
+func (h *Harness) CreateUpdbIdentity(t testing.TB, base string, roleAttributes ...string) *UpdbIdentity {
+	t.Helper()
+	unique := uniqueName(t, base)
+	password := randomPassword(t)
+
+	idDir := filepath.Join(h.home, "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("creating identities dir: %v", err)
+	}
+	jwtPath := filepath.Join(idDir, unique+".jwt")
+
+	args := []string{"edge", "create", "identity", unique, "--updb", unique, "--jwt-output-file", jwtPath}
+	if len(roleAttributes) > 0 {
+		args = append(args, "--role-attributes", strings.Join(roleAttributes, ","))
+	}
+	h.Cli(t, args...)
+	t.Cleanup(func() {
+		// best-effort; the whole environment is discarded at teardown regardless
+		_, _ = h.cli.Run(context.Background(), "edge", "delete", "identity", unique)
+	})
+
+	// complete the UPDB enrollment, which sets the password on the controller
+	h.Cli(t, "edge", "enroll", jwtPath, "--username", unique, "--password", password)
+
+	return &UpdbIdentity{name: unique, username: unique, password: password}
+}
+
+// NewUpdbSdkContext builds an authenticated ziti.Context for a UPDB identity,
+// using its username/password as the primary credential, registering close with
+// t.
+func (h *Harness) NewUpdbSdkContext(t testing.TB, id *UpdbIdentity) ziti.Context {
+	t.Helper()
+
+	ctrlURL := "https://" + h.ctrl.hostPort
+	caPool, err := ziti.GetControllerWellKnownCaPool(ctrlURL)
+	require.NoError(t, err, "fetching controller ca pool")
+
+	creds := edgeApis.NewUpdbCredentials(id.username, id.password)
+	creds.CaPool = caPool
+
+	ctx, err := ziti.NewContext(&ziti.Config{
+		ZtAPI:       ctrlURL + "/edge/client/v1",
+		Credentials: creds,
+	})
+	require.NoError(t, err, "creating updb sdk context")
+	t.Cleanup(ctx.Close)
+
+	require.NoError(t, ctx.Authenticate(), "authenticating with updb")
+	return ctx
+}
+
+// randomPassword returns a password meeting typical complexity requirements
+// (mixed case, digit, symbol) with random entropy.
+func randomPassword(t testing.TB) string {
+	t.Helper()
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("generating password: %v", err)
+	}
+	return "Pw1!" + hex.EncodeToString(b)
+}

--- a/acceptance/tests/updb_test.go
+++ b/acceptance/tests/updb_test.go
@@ -1,0 +1,57 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_AuthModes_Updb covers acceptance batch item #6d: a username/password
+// (UPDB) identity authenticates through the SDK and dials a service, and the
+// authenticated context survives an api-session token refresh (the new token is
+// propagated to the edge routers) and keeps dialing. UPDB is a common consumer
+// credential path distinct from cert and ext-JWT auth.
+func Test_AuthModes_Updb(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateUpdbIdentity(t, "updb-client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewUpdbSdkContext(t, clientID)
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "updb auth round-trip")
+
+	// token refresh through the SDK context: refresh the api session and confirm
+	// the context still dials after the new token propagates to the edge routers.
+	refreshErr, erErr := clientCtx.(*ziti.ContextImpl).RefreshApiSession()
+	require.NoError(t, refreshErr, "updb api-session refresh should succeed")
+	require.NoError(t, erErr, "edge-router token propagation should succeed after refresh")
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "updb post-refresh round-trip")
+}


### PR DESCRIPTION
Adds an acceptance test for username/password (UPDB) login through the SDK, plus an api-session token refresh: a UPDB identity dials a service, then refreshes its session and dials again.

Harness: helpers to create and enroll a UPDB identity and build a UPDB-authenticated context.

Touches acceptance/harness/services.go; may need a trivial rebase if another harness PR lands first.