### PR TITLE
Add acceptance test for service-access update propagation

### DIFF
--- a/acceptance/harness/services.go
+++ b/acceptance/harness/services.go
@@ -44,22 +44,41 @@ func (h *Harness) CreateService(t testing.TB, base string) *Service {
 	return &Service{name: name}
 }
 
-// GrantDial creates a Dial service policy granting the identities access to svc.
-// Per the isolation contract the policy targets the named entities explicitly,
-// never #all or shared attributes.
-func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...*Identity) {
+// Policy is a created policy. Beyond its automatic best-effort cleanup it can be
+// deleted mid-test, e.g. to revoke access and observe the SDK react.
+type Policy struct {
+	h    *Harness
+	kind string
+	name string
+}
+
+// Name returns the policy's unique name on the controller.
+func (p *Policy) Name() string { return p.name }
+
+// Delete removes the policy now (in addition to the automatic cleanup), failing
+// the test on error. Used to revoke access during a test.
+func (p *Policy) Delete(t testing.TB) {
 	t.Helper()
-	h.createServicePolicy(t, "Dial", svc, ids)
+	p.h.Cli(t, "edge", "delete", p.kind, p.name)
+}
+
+// GrantDial creates a Dial service policy granting the identities access to svc
+// and returns a handle for revoking it. Per the isolation contract the policy
+// targets the named entities explicitly, never #all or shared attributes.
+func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...*Identity) *Policy {
+	t.Helper()
+	return h.createServicePolicy(t, "Dial", svc, ids)
 }
 
 // GrantBind creates a Bind service policy granting the identities hosting access
-// to svc, targeting the named entities explicitly.
-func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...*Identity) {
+// to svc, targeting the named entities explicitly, and returns a handle for
+// revoking it.
+func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...*Identity) *Policy {
 	t.Helper()
-	h.createServicePolicy(t, "Bind", svc, ids)
+	return h.createServicePolicy(t, "Bind", svc, ids)
 }
 
-func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []*Identity) {
+func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []*Identity) *Policy {
 	t.Helper()
 	name := uniqueName(t, strings.ToLower(polType))
 	h.Cli(t, "edge", "create", "service-policy", name, polType,
@@ -68,6 +87,7 @@ func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service
 	t.Cleanup(func() {
 		_, _ = h.cli.Run(context.Background(), "edge", "delete", "service-policy", name)
 	})
+	return &Policy{h: h, kind: "service-policy", name: name}
 }
 
 // GrantRouterAccess creates an edge-router policy letting the identities use the

--- a/acceptance/tests/service_update_test.go
+++ b/acceptance/tests/service_update_test.go
@@ -1,0 +1,100 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// requireServiceEvent waits for an event naming service on ch, draining events
+// for other services until it matches or the deadline elapses.
+func requireServiceEvent(t testing.TB, ch <-chan string, service, desc string) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case got := <-ch:
+			if got == service {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("%s: never observed event for service %s", desc, service)
+		}
+	}
+}
+
+// Test_ServiceUpdatePropagation covers acceptance batch item #6c: after an
+// initial dial, editing a service's access (policy edits) is reflected by the
+// SDK. The ServiceChanged/Removed/Added events fire on a forced refresh, and the
+// sessionless service-edge-router cache invalidates rather than dialing stale
+// data: a dial fails once access is revoked and succeeds again once re-granted.
+func Test_ServiceUpdatePropagation(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	dialPolicy := h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+	// baseline: the service is dialable before any access edits
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "service-update baseline")
+
+	added := make(chan string, 8)
+	changed := make(chan string, 8)
+	removed := make(chan string, 8)
+	clientCtx.Events().AddServiceAddedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { added <- *s.Name })
+	clientCtx.Events().AddServiceChangedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { changed <- *s.Name })
+	clientCtx.Events().AddServiceRemovedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { removed <- *s.Name })
+
+	// CHANGED: granting Bind changes the client's permissions on the service,
+	// which the SDK detects as a service change.
+	bindPolicy := h.GrantBind(t, svc, clientID)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, changed, svc.Name(), "ServiceChanged after permission grant")
+
+	// REMOVED: revoke all access; the service should drop out of the client's
+	// view and its cached session/ER data should be invalidated.
+	dialPolicy.Delete(t)
+	bindPolicy.Delete(t)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, removed, svc.Name(), "ServiceRemoved after access revoke")
+
+	// the SDK must reflect the revocation, not dial stale cached data
+	_, err := clientCtx.Dial(svc.Name())
+	require.Error(t, err, "dial after access revoke should fail rather than use stale cache")
+
+	// ADDED: re-grant dial; the service reappears and dials again
+	h.GrantDial(t, svc, clientID)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, added, svc.Name(), "ServiceAdded after re-grant")
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "service-update after re-grant")
+}


### PR DESCRIPTION
Adds an acceptance test that the SDK reflects service-access edits made after an initial dial: the changed/removed/added service events fire on a refresh, and cached state is invalidated rather than dialing stale data (a dial fails once access is revoked and succeeds again once re-granted).

Harness: a deletable policy handle so a test can revoke access mid-run.

Touches acceptance/harness/services.go; may need a trivial rebase if another harness PR lands first.