### PR TITLE
Add acceptance test suite

### DIFF
--- a/acceptance/harness/identity.go
+++ b/acceptance/harness/identity.go
@@ -28,6 +28,13 @@ import (
 	"testing"
 )
 
+// NamedEntity is anything with a controller name. The policy grant helpers take
+// it so they work across identity credential types (cert Identity, UpdbIdentity,
+// ...) without overloading per type.
+type NamedEntity interface {
+	Name() string
+}
+
 // Identity is a created-and-enrolled identity, usable to build an SDK context.
 type Identity struct {
 	name     string

--- a/acceptance/harness/sdk.go
+++ b/acceptance/harness/sdk.go
@@ -40,6 +40,30 @@ func (h *Harness) NewLegacySdkContext(t testing.TB, id *Identity) ziti.Context {
 	return h.newSdkContext(t, id, true)
 }
 
+// NewSdkContextWithConfigTypes is NewSdkContext that also requests the given
+// service config types, so the context populates per-service config (e.g.
+// intercept.v1) used by GetServiceForAddr/DialAddr.
+func (h *Harness) NewSdkContextWithConfigTypes(t testing.TB, id *Identity, configTypes ...string) ziti.Context {
+	t.Helper()
+
+	cfg, err := ziti.NewConfigFromFile(id.ConfigPath())
+	if err != nil {
+		t.Fatalf("loading identity config %s: %v", id.ConfigPath(), err)
+	}
+	cfg.ConfigTypes = append(cfg.ConfigTypes, configTypes...)
+
+	ctx, err := ziti.NewContext(cfg)
+	if err != nil {
+		t.Fatalf("creating sdk context for %s: %v", id.Name(), err)
+	}
+	t.Cleanup(ctx.Close)
+
+	if err := ctx.Authenticate(); err != nil {
+		t.Fatalf("authenticating %s: %v", id.Name(), err)
+	}
+	return ctx
+}
+
 func (h *Harness) newSdkContext(t testing.TB, id *Identity, forceLegacy bool) ziti.Context {
 	t.Helper()
 

--- a/acceptance/harness/services.go
+++ b/acceptance/harness/services.go
@@ -44,22 +44,41 @@ func (h *Harness) CreateService(t testing.TB, base string) *Service {
 	return &Service{name: name}
 }
 
-// GrantDial creates a Dial service policy granting the identities access to svc.
-// Per the isolation contract the policy targets the named entities explicitly,
-// never #all or shared attributes.
-func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...NamedEntity) {
+// Policy is a created policy. Beyond its automatic best-effort cleanup it can be
+// deleted mid-test, e.g. to revoke access and observe the SDK react.
+type Policy struct {
+	h    *Harness
+	kind string
+	name string
+}
+
+// Name returns the policy's unique name on the controller.
+func (p *Policy) Name() string { return p.name }
+
+// Delete removes the policy now (in addition to the automatic cleanup), failing
+// the test on error. Used to revoke access during a test.
+func (p *Policy) Delete(t testing.TB) {
 	t.Helper()
-	h.createServicePolicy(t, "Dial", svc, ids)
+	p.h.Cli(t, "edge", "delete", p.kind, p.name)
+}
+
+// GrantDial creates a Dial service policy granting the identities access to svc
+// and returns a handle for revoking it. Per the isolation contract the policy
+// targets the named entities explicitly, never #all or shared attributes.
+func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...NamedEntity) *Policy {
+	t.Helper()
+	return h.createServicePolicy(t, "Dial", svc, ids)
 }
 
 // GrantBind creates a Bind service policy granting the identities hosting access
-// to svc, targeting the named entities explicitly.
-func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...NamedEntity) {
+// to svc, targeting the named entities explicitly, and returns a handle for
+// revoking it.
+func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...NamedEntity) *Policy {
 	t.Helper()
-	h.createServicePolicy(t, "Bind", svc, ids)
+	return h.createServicePolicy(t, "Bind", svc, ids)
 }
 
-func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []NamedEntity) {
+func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []NamedEntity) *Policy {
 	t.Helper()
 	name := uniqueName(t, strings.ToLower(polType))
 	h.Cli(t, "edge", "create", "service-policy", name, polType,
@@ -68,6 +87,7 @@ func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service
 	t.Cleanup(func() {
 		_, _ = h.cli.Run(context.Background(), "edge", "delete", "service-policy", name)
 	})
+	return &Policy{h: h, kind: "service-policy", name: name}
 }
 
 // GrantRouterAccess creates an edge-router policy letting the identities use the

--- a/acceptance/harness/services.go
+++ b/acceptance/harness/services.go
@@ -47,19 +47,19 @@ func (h *Harness) CreateService(t testing.TB, base string) *Service {
 // GrantDial creates a Dial service policy granting the identities access to svc.
 // Per the isolation contract the policy targets the named entities explicitly,
 // never #all or shared attributes.
-func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...*Identity) {
+func (h *Harness) GrantDial(t testing.TB, svc *Service, ids ...NamedEntity) {
 	t.Helper()
 	h.createServicePolicy(t, "Dial", svc, ids)
 }
 
 // GrantBind creates a Bind service policy granting the identities hosting access
 // to svc, targeting the named entities explicitly.
-func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...*Identity) {
+func (h *Harness) GrantBind(t testing.TB, svc *Service, ids ...NamedEntity) {
 	t.Helper()
 	h.createServicePolicy(t, "Bind", svc, ids)
 }
 
-func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []*Identity) {
+func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service, ids []NamedEntity) {
 	t.Helper()
 	name := uniqueName(t, strings.ToLower(polType))
 	h.Cli(t, "edge", "create", "service-policy", name, polType,
@@ -72,7 +72,7 @@ func (h *Harness) createServicePolicy(t testing.TB, polType string, svc *Service
 
 // GrantRouterAccess creates an edge-router policy letting the identities use the
 // router, targeting both sides by name.
-func (h *Harness) GrantRouterAccess(t testing.TB, r *Router, ids ...*Identity) {
+func (h *Harness) GrantRouterAccess(t testing.TB, r *Router, ids ...NamedEntity) {
 	t.Helper()
 	name := uniqueName(t, "erp")
 	h.Cli(t, "edge", "create", "edge-router-policy", name,
@@ -96,7 +96,7 @@ func (h *Harness) GrantServiceRouterAccess(t testing.TB, svc *Service, r *Router
 	})
 }
 
-func identityRoles(ids []*Identity) string {
+func identityRoles(ids []NamedEntity) string {
 	roles := make([]string, len(ids))
 	for i, id := range ids {
 		roles[i] = "@" + id.Name()

--- a/acceptance/harness/services.go
+++ b/acceptance/harness/services.go
@@ -36,8 +36,20 @@ func (s *Service) Name() string {
 // isolation contract, with best-effort cleanup.
 func (h *Harness) CreateService(t testing.TB, base string) *Service {
 	t.Helper()
+	return h.CreateServiceWithConfigs(t, base)
+}
+
+// CreateServiceWithConfigs creates a service associated with the given config
+// names (e.g. an intercept.v1 config for intercept-style dialing), uniquely
+// named with best-effort cleanup.
+func (h *Harness) CreateServiceWithConfigs(t testing.TB, base string, configs ...string) *Service {
+	t.Helper()
 	name := uniqueName(t, base)
-	h.Cli(t, "edge", "create", "service", name)
+	args := []string{"edge", "create", "service", name}
+	if len(configs) > 0 {
+		args = append(args, "--configs", strings.Join(configs, ","))
+	}
+	h.Cli(t, args...)
 	t.Cleanup(func() {
 		_, _ = h.cli.Run(context.Background(), "edge", "delete", "service", name)
 	})
@@ -60,6 +72,20 @@ func (p *Policy) Name() string { return p.name }
 func (p *Policy) Delete(t testing.TB) {
 	t.Helper()
 	p.h.Cli(t, "edge", "delete", p.kind, p.name)
+}
+
+// CreateConfig creates a config of the given type with the given JSON value,
+// uniquely named with best-effort cleanup, and returns its name. The config
+// types it references (e.g. intercept.v1) are created by the controller
+// quickstart bootstrap.
+func (h *Harness) CreateConfig(t testing.TB, base, configType, jsonValue string) string {
+	t.Helper()
+	name := uniqueName(t, base)
+	h.Cli(t, "edge", "create", "config", name, configType, jsonValue)
+	t.Cleanup(func() {
+		_, _ = h.cli.Run(context.Background(), "edge", "delete", "config", name)
+	})
+	return name
 }
 
 // GrantDial creates a Dial service policy granting the identities access to svc

--- a/acceptance/harness/updb.go
+++ b/acceptance/harness/updb.go
@@ -1,0 +1,115 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package harness
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	edgeApis "github.com/openziti/sdk-golang/v2/edge-apis"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// UpdbIdentity is a created identity that authenticates with a username/password
+// (UPDB) credential rather than a client certificate.
+type UpdbIdentity struct {
+	name     string
+	username string
+	password string
+}
+
+// Name returns the identity's unique name on the controller.
+func (i *UpdbIdentity) Name() string { return i.name }
+
+// Username returns the UPDB username (equal to the identity name).
+func (i *UpdbIdentity) Username() string { return i.username }
+
+// Password returns the UPDB password set during enrollment.
+func (i *UpdbIdentity) Password() string { return i.password }
+
+// CreateUpdbIdentity creates an identity with a UPDB enrollment and completes
+// that enrollment via the CLI, setting its password. The username equals the
+// identity name. roleAttributes, if given, are set for use in targeted policies.
+// The identity is uniquely named per the isolation contract, with best-effort
+// cleanup.
+func (h *Harness) CreateUpdbIdentity(t testing.TB, base string, roleAttributes ...string) *UpdbIdentity {
+	t.Helper()
+	unique := uniqueName(t, base)
+	password := randomPassword(t)
+
+	idDir := filepath.Join(h.home, "identities")
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		t.Fatalf("creating identities dir: %v", err)
+	}
+	jwtPath := filepath.Join(idDir, unique+".jwt")
+
+	args := []string{"edge", "create", "identity", unique, "--updb", unique, "--jwt-output-file", jwtPath}
+	if len(roleAttributes) > 0 {
+		args = append(args, "--role-attributes", strings.Join(roleAttributes, ","))
+	}
+	h.Cli(t, args...)
+	t.Cleanup(func() {
+		// best-effort; the whole environment is discarded at teardown regardless
+		_, _ = h.cli.Run(context.Background(), "edge", "delete", "identity", unique)
+	})
+
+	// complete the UPDB enrollment, which sets the password on the controller
+	h.Cli(t, "edge", "enroll", jwtPath, "--username", unique, "--password", password)
+
+	return &UpdbIdentity{name: unique, username: unique, password: password}
+}
+
+// NewUpdbSdkContext builds an authenticated ziti.Context for a UPDB identity,
+// using its username/password as the primary credential, registering close with
+// t.
+func (h *Harness) NewUpdbSdkContext(t testing.TB, id *UpdbIdentity) ziti.Context {
+	t.Helper()
+
+	ctrlURL := "https://" + h.ctrl.hostPort
+	caPool, err := ziti.GetControllerWellKnownCaPool(ctrlURL)
+	require.NoError(t, err, "fetching controller ca pool")
+
+	creds := edgeApis.NewUpdbCredentials(id.username, id.password)
+	creds.CaPool = caPool
+
+	ctx, err := ziti.NewContext(&ziti.Config{
+		ZtAPI:       ctrlURL + "/edge/client/v1",
+		Credentials: creds,
+	})
+	require.NoError(t, err, "creating updb sdk context")
+	t.Cleanup(ctx.Close)
+
+	require.NoError(t, ctx.Authenticate(), "authenticating with updb")
+	return ctx
+}
+
+// randomPassword returns a password meeting typical complexity requirements
+// (mixed case, digit, symbol) with random entropy.
+func randomPassword(t testing.TB) string {
+	t.Helper()
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("generating password: %v", err)
+	}
+	return "Pw1!" + hex.EncodeToString(b)
+}

--- a/acceptance/tests/conn_semantics_test.go
+++ b/acceptance/tests/conn_semantics_test.go
@@ -1,0 +1,136 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/openziti/sdk-golang/v2/ziti/edge"
+	"github.com/stretchr/testify/require"
+)
+
+// acceptedConnInfo captures the dialer-supplied metadata the host sees on an
+// accepted connection.
+type acceptedConnInfo struct {
+	sourceIdentifier   string
+	appData            []byte
+	dialerIdentityId   string
+	dialerIdentityName string
+}
+
+// startMetadataCapturingServer hosts service on hostCtx and, for the first
+// accepted connection, records the dialer metadata the host can observe
+// (caller id, app data, dialer identity) before echoing and closing. The
+// captured info is delivered on the returned channel.
+func startMetadataCapturingServer(t testing.TB, hostCtx ziti.Context, service string) <-chan acceptedConnInfo {
+	t.Helper()
+	sdkXgress := true
+	listener, err := hostCtx.ListenWithOptions(service, &ziti.ListenOptions{
+		WaitForNEstablishedListeners: 1,
+		ConnectTimeout:               30 * time.Second,
+		SdkFlowControl:               &sdkXgress,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	infoC := make(chan acceptedConnInfo, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		// edge.Conn carries the dialer metadata accessors; Accept returns a
+		// net.Conn whose concrete type is an edge ServiceConn.
+		if sc, ok := conn.(edge.ServiceConn); ok {
+			infoC <- acceptedConnInfo{
+				sourceIdentifier:   sc.SourceIdentifier(),
+				appData:            sc.GetAppData(),
+				dialerIdentityId:   sc.GetDialerIdentityId(),
+				dialerIdentityName: sc.GetDialerIdentityName(),
+			}
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		data, _ := io.ReadAll(conn)
+		_, _ = conn.Write(data)
+		_ = conn.Close()
+	}()
+	return infoC
+}
+
+// Test_ConnSemantics_DialerMetadata proves the dialer metadata round-trip: the
+// caller id (the dialing identity's name, set automatically by the SDK) and the
+// dialer-supplied AppData are visible on the host's accepted connection. It also
+// re-exercises the core stream contract (half-close + read-to-EOF) via the echo
+// round trip, so the metadata assertions ride on a proven data plane rather than
+// a connection that silently failed to carry data.
+func Test_ConnSemantics_DialerMetadata(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	infoC := startMetadataCapturingServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+
+	appData := []byte("app-data-round-trip")
+	conn := dialWithOptionsRetry(t, clientCtx, svc.Name(), &ziti.DialOptions{
+		ConnectTimeout: 30 * time.Second,
+		AppData:        appData,
+	})
+	defer func() { _ = conn.Close() }()
+
+	payload := "dialer-metadata round-trip"
+	_, err := conn.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, conn.CloseWrite(), "half-close the send side")
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+	echoed, err := io.ReadAll(conn)
+	require.NoError(t, err, "no echo within 30s: the data plane delivered nothing back")
+	require.Equal(t, payload, string(echoed))
+
+	select {
+	case info := <-infoC:
+		require.Equal(t, clientID.Name(), info.sourceIdentifier,
+			"host should see the dialing identity's name as the caller id")
+		require.Equal(t, appData, info.appData,
+			"host should see the dialer-supplied app data")
+		// the dialer identity (id + name) is a 2.0+ capability; older controllers
+		// do not populate the dialer identity headers on the dial request
+		if h.Version().AtLeast("2.0.0") {
+			require.Equal(t, clientID.Name(), info.dialerIdentityName,
+				"host should see the dialer identity name")
+			require.NotEmpty(t, info.dialerIdentityId,
+				"host should see the dialer identity id")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("host never reported accepted-connection metadata")
+	}
+}

--- a/acceptance/tests/intercept_test.go
+++ b/acceptance/tests/intercept_test.go
@@ -1,0 +1,138 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	interceptV1ConfigType = "intercept.v1"
+	clientV1ConfigType    = "ziti-tunneler-client.v1"
+)
+
+// requireEchoViaAddr resolves addr to a service via the context's intercepts and
+// dials it with DialAddr, then proves the data plane with a write/half-close/
+// read-to-EOF echo. It retries the initial dial like dialWithRetry, since
+// terminator/policy propagation can lag router readiness.
+func requireEchoViaAddr(t testing.TB, ctx ziti.Context, network, addr, payload string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := ctx.DialAddr(network, addr)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, err = conn.Write([]byte(payload))
+		require.NoError(t, err)
+		require.NoError(t, conn.CloseWrite(), "half-close the send side")
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+		echoed, err := io.ReadAll(conn)
+		require.NoError(t, err, "no echo within 30s on DialAddr conn")
+		require.Equal(t, payload, string(echoed))
+		return
+	}
+	t.Fatalf("DialAddr %s/%s never succeeded: %v", network, addr, lastErr)
+}
+
+// Test_InterceptDial covers acceptance batch item #6f for an intercept.v1
+// config: the tunneler-style entry point. GetServiceForAddr scores an exact
+// host+port match at 0 and rejects a non-matching port, and DialAddr resolves
+// the address to that service and round-trips data.
+func Test_InterceptDial(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	const host = "intercept-v1.test"
+	const port = 8080
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+
+	cfg := h.CreateConfig(t, "intercept", interceptV1ConfigType,
+		fmt.Sprintf(`{"protocols":["tcp"],"addresses":["%s"],"portRanges":[{"low":%d,"high":%d}]}`, host, port, port))
+	svc := h.CreateServiceWithConfigs(t, "echo", cfg)
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContextWithConfigTypes(t, clientID, interceptV1ConfigType)
+
+	matched, score, err := clientCtx.GetServiceForAddr("tcp", host, port)
+	require.NoError(t, err, "intercept should match the configured host:port")
+	require.Equal(t, svc.Name(), *matched.Name)
+	require.Equal(t, 0, score, "an exact host+port match scores 0")
+
+	_, _, err = clientCtx.GetServiceForAddr("tcp", host, port+1)
+	require.Error(t, err, "a non-matching port should resolve to no service")
+
+	requireEchoViaAddr(t, clientCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)), "intercept dial round-trip")
+}
+
+// Test_InterceptDial_ClientConfigConversion covers the #6f conversion path: a
+// service carrying only a ziti-tunneler-client.v1 config is still addressable,
+// because the SDK converts that config to an intercept (ClientConfigV1 ->
+// InterceptV1). GetServiceForAddr matches the converted host+port and DialAddr
+// round-trips.
+func Test_InterceptDial_ClientConfigConversion(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	const host = "client-cfg.test"
+	const port = 8080
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+
+	cfg := h.CreateConfig(t, "client", clientV1ConfigType,
+		fmt.Sprintf(`{"hostname":"%s","port":%d}`, host, port))
+	svc := h.CreateServiceWithConfigs(t, "echo", cfg)
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContextWithConfigTypes(t, clientID, clientV1ConfigType)
+
+	matched, _, err := clientCtx.GetServiceForAddr("tcp", host, port)
+	require.NoError(t, err, "the client config should convert to a matchable intercept")
+	require.Equal(t, svc.Name(), *matched.Name)
+
+	requireEchoViaAddr(t, clientCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)), "client-config dial round-trip")
+}

--- a/acceptance/tests/revocation_test.go
+++ b/acceptance/tests/revocation_test.go
@@ -1,0 +1,68 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_Revocation_IdentityDelete covers acceptance batch item #4 (revocation
+// enforcement): once a dialing identity is deleted, the controller enforces the
+// revocation and the SDK can no longer dial the service. A freshly revoked
+// identity may briefly dial on cached session state, so enforcement is asserted
+// as eventual within a bounded window rather than on a single attempt.
+//
+// This covers the new-dial-refused path. Reaper-driven teardown of an already
+// established circuit is a separate behavior (it needs a hold-open host and is
+// reaper-interval sensitive) and is tracked as a follow-up.
+func Test_Revocation_IdentityDelete(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "revocation baseline")
+
+	// revoke the client by deleting its identity
+	h.Cli(t, "edge", "delete", "identity", clientID.Name())
+
+	// enforcement: the client can no longer dial. Poll until the dial is refused,
+	// closing any connection that still briefly succeeds on cached state.
+	require.Eventually(t, func() bool {
+		conn, err := clientCtx.Dial(svc.Name())
+		if err == nil {
+			_ = conn.Close()
+			return false
+		}
+		return true
+	}, 60*time.Second, time.Second, "dial should be refused after the identity is revoked")
+}

--- a/acceptance/tests/service_update_test.go
+++ b/acceptance/tests/service_update_test.go
@@ -1,0 +1,100 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/edge-api/rest_model"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// requireServiceEvent waits for an event naming service on ch, draining events
+// for other services until it matches or the deadline elapses.
+func requireServiceEvent(t testing.TB, ch <-chan string, service, desc string) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case got := <-ch:
+			if got == service {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("%s: never observed event for service %s", desc, service)
+		}
+	}
+}
+
+// Test_ServiceUpdatePropagation covers acceptance batch item #6c: after an
+// initial dial, editing a service's access (policy edits) is reflected by the
+// SDK. The ServiceChanged/Removed/Added events fire on a forced refresh, and the
+// sessionless service-edge-router cache invalidates rather than dialing stale
+// data: a dial fails once access is revoked and succeeds again once re-granted.
+func Test_ServiceUpdatePropagation(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	dialPolicy := h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+	// baseline: the service is dialable before any access edits
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "service-update baseline")
+
+	added := make(chan string, 8)
+	changed := make(chan string, 8)
+	removed := make(chan string, 8)
+	clientCtx.Events().AddServiceAddedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { added <- *s.Name })
+	clientCtx.Events().AddServiceChangedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { changed <- *s.Name })
+	clientCtx.Events().AddServiceRemovedListener(func(_ ziti.Context, s *rest_model.ServiceDetail) { removed <- *s.Name })
+
+	// CHANGED: granting Bind changes the client's permissions on the service,
+	// which the SDK detects as a service change.
+	bindPolicy := h.GrantBind(t, svc, clientID)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, changed, svc.Name(), "ServiceChanged after permission grant")
+
+	// REMOVED: revoke all access; the service should drop out of the client's
+	// view and its cached session/ER data should be invalidated.
+	dialPolicy.Delete(t)
+	bindPolicy.Delete(t)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, removed, svc.Name(), "ServiceRemoved after access revoke")
+
+	// the SDK must reflect the revocation, not dial stale cached data
+	_, err := clientCtx.Dial(svc.Name())
+	require.Error(t, err, "dial after access revoke should fail rather than use stale cache")
+
+	// ADDED: re-grant dial; the service reappears and dials again
+	h.GrantDial(t, svc, clientID)
+	require.NoError(t, clientCtx.RefreshServices())
+	requireServiceEvent(t, added, svc.Name(), "ServiceAdded after re-grant")
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "service-update after re-grant")
+}

--- a/acceptance/tests/token_refresh_test.go
+++ b/acceptance/tests/token_refresh_test.go
@@ -1,0 +1,112 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/acceptance/harness"
+	edgeApis "github.com/openziti/sdk-golang/v2/edge-apis"
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// apiSessionToken returns the current api-session token for ctx.
+func apiSessionToken(t testing.TB, ctx ziti.Context) string {
+	t.Helper()
+	apiSession := ctx.(*ziti.ContextImpl).CtrlClt.GetCurrentApiSession()
+	require.NotNil(t, apiSession, "context has no current api session")
+	return string(apiSession.GetToken())
+}
+
+// refreshApiSession refreshes ctx's api session, failing on a functional refresh
+// error or an edge-router token propagation error.
+func refreshApiSession(t testing.TB, ctx ziti.Context) {
+	t.Helper()
+	refreshErr, erErr := ctx.(*ziti.ContextImpl).RefreshApiSession()
+	require.NoError(t, refreshErr, "api-session refresh should succeed")
+	require.NoError(t, erErr, "edge-router token propagation should succeed after refresh")
+}
+
+// Test_TokenRefresh_DialContinuity covers acceptance batch item #6: across
+// several api-session refreshes the context keeps dialing, and on OIDC each
+// refresh rotates the access token (the new token propagates to the edge
+// routers, so the next dial uses it).
+func Test_TokenRefresh_DialContinuity(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "token-refresh baseline")
+
+	// rotation is an OIDC property (the legacy session token is stable across a
+	// refresh); only assert it on OIDC, but assert dial continuity either way.
+	checkRotation := harness.ApiSessionType(t, clientCtx) == edgeApis.ApiSessionTypeOidc
+
+	for i := 0; i < 3; i++ {
+		prev := apiSessionToken(t, clientCtx)
+		refreshApiSession(t, clientCtx)
+		if checkRotation {
+			require.NotEqual(t, prev, apiSessionToken(t, clientCtx),
+				"each OIDC refresh should rotate the access token")
+		}
+		requireEchoRoundTrip(t, clientCtx, svc.Name(), "token-refresh dial after refresh")
+	}
+}
+
+// Test_HostingContinuity_AcrossRefresh covers acceptance batch item #6b: a
+// hosted terminator survives the host's api-session/token refresh. After the
+// host refreshes, the terminator stays registered and the service keeps
+// accepting dials. This is distinct from the dial path: bind/listen uses service
+// sessions and terminators, which must ride the refresh.
+func Test_HostingContinuity_AcrossRefresh(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateIdentity(t, "client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewSdkContext(t, clientID)
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "hosting-continuity baseline")
+
+	// refresh the host's session twice; the terminator must survive each time
+	for i := 0; i < 2; i++ {
+		refreshApiSession(t, hostCtx)
+		requireEchoRoundTrip(t, clientCtx, svc.Name(), "hosting-continuity dial after host refresh")
+	}
+}

--- a/acceptance/tests/updb_test.go
+++ b/acceptance/tests/updb_test.go
@@ -1,0 +1,57 @@
+//go:build acceptance
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/openziti/sdk-golang/v2/ziti"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_AuthModes_Updb covers acceptance batch item #6d: a username/password
+// (UPDB) identity authenticates through the SDK and dials a service, and the
+// authenticated context survives an api-session token refresh (the new token is
+// propagated to the edge routers) and keeps dialing. UPDB is a common consumer
+// credential path distinct from cert and ext-JWT auth.
+func Test_AuthModes_Updb(t *testing.T) {
+	h := shared // shared test harness, set up in main_test.go
+	r := h.DefaultRouter()
+
+	hostID := h.CreateIdentity(t, "host")
+	clientID := h.CreateUpdbIdentity(t, "updb-client")
+	svc := h.CreateService(t, "echo")
+	h.GrantBind(t, svc, hostID)
+	h.GrantDial(t, svc, clientID)
+	h.GrantRouterAccess(t, r, hostID, clientID)
+	h.GrantServiceRouterAccess(t, svc, r)
+
+	hostCtx := h.NewSdkContext(t, hostID)
+	startEchoServer(t, hostCtx, svc.Name())
+
+	clientCtx := h.NewUpdbSdkContext(t, clientID)
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "updb auth round-trip")
+
+	// token refresh through the SDK context: refresh the api session and confirm
+	// the context still dials after the new token propagates to the edge routers.
+	refreshErr, erErr := clientCtx.(*ziti.ContextImpl).RefreshApiSession()
+	require.NoError(t, refreshErr, "updb api-session refresh should succeed")
+	require.NoError(t, erErr, "edge-router token propagation should succeed after refresh")
+	requireEchoRoundTrip(t, clientCtx, svc.Name(), "updb post-refresh round-trip")
+}


### PR DESCRIPTION
Consolidates the acceptance-test branches (previously PRs #960-#965) into a single PR with one commit per acceptance test, so the suite reviews and merges together.

Each commit adds one acceptance test plus any harness support it needs:

- Dialer connection metadata (conn semantics)
- UPDB (username/password) auth
- Service-access update propagation
- Address-based (intercept) dialing
- Token refresh and hosting continuity
- Revocation enforcement

The shared harness changes that overlapped across branches (`acceptance/harness/services.go`) are reconciled: the policy-grant helpers take the `NamedEntity` interface and return a `*Policy` handle so access can be revoked mid-test.
