### PR TITLE
Fix LinkSendBuffer goroutine leak after half-close

### DIFF
--- a/xgress/deadline.go
+++ b/xgress/deadline.go
@@ -18,40 +18,28 @@ package xgress
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/openziti/foundation/v2/concurrenz"
 )
 
-// deadlineCallback holds a timer channel and the function to call when it fires.
-// It is stored in an atomic slot on the LinkSendBuffer so that the run loop can
-// include the timer channel in its select without spawning extra goroutines.
-type deadlineCallback struct {
-	C    <-chan time.Time
-	fire func()
-}
-
 // deadlineControl manages a deadline with notification channel semantics.
 // When the deadline expires (or is set in the past), the Done channel is closed.
 // Clearing the deadline (zero time) resets the channel to a fresh open one.
 //
-// Future deadlines register a timer channel in the slot for processing by the
-// LinkSendBuffer run loop and send a wake event so the loop picks it up.
+// Future deadlines use the runtime timer heap. time.AfterFunc only starts a
+// goroutine when the deadline fires, so no persistent deadline goroutine is
+// needed while the timer is pending.
 type deadlineControl struct {
 	deadline         concurrenz.AtomicValue[time.Time]
 	doneNotify       concurrenz.AtomicValue[chan struct{}]
 	doneNotifyClosed bool
 	timer            *time.Timer
-	slot             *atomic.Pointer[deadlineCallback]
-	events           chan sendBufferEvent
 	lock             sync.Mutex
 }
 
-func (dc *deadlineControl) init(slot *atomic.Pointer[deadlineCallback], events chan sendBufferEvent) {
+func (dc *deadlineControl) init() {
 	dc.doneNotify.Store(make(chan struct{}))
-	dc.slot = slot
-	dc.events = events
 }
 
 // Done returns a channel that is closed when the current deadline expires.
@@ -71,7 +59,6 @@ func (dc *deadlineControl) SetDeadline(t time.Time) error {
 		dc.timer.Stop()
 		dc.timer = nil
 	}
-	dc.slot.Store(nil)
 
 	if t.IsZero() {
 		if dc.doneNotifyClosed {
@@ -97,16 +84,7 @@ func (dc *deadlineControl) SetDeadline(t time.Time) error {
 		dc.doneNotifyClosed = false
 	}
 
-	dc.timer = time.NewTimer(d)
-	dc.slot.Store(&deadlineCallback{
-		C:    dc.timer.C,
-		fire: func() { dc.fireDeadline(t) },
-	})
-	// Wake the run loop so it re-evaluates with the new timer channel
-	select {
-	case dc.events <- deadlineWakeEvent{}:
-	default:
-	}
+	dc.timer = time.AfterFunc(d, func() { dc.fireDeadline(t) })
 
 	return nil
 }

--- a/xgress/link_send_buffer.go
+++ b/xgress/link_send_buffer.go
@@ -57,9 +57,7 @@ type LinkSendBuffer struct {
 	lastRtt               uint16
 	lastRetransmitTime    int64
 	closeWhenEmpty        atomic.Bool
-	events                chan sendBufferEvent
-	readDeadlineCb        atomic.Pointer[deadlineCallback]
-	writeDeadlineCb       atomic.Pointer[deadlineCallback]
+	inspectRequests       chan *sendBufferInspectEvent
 	blockedSince          time.Time
 	closeStart            time.Time
 }
@@ -119,7 +117,7 @@ func NewLinkSendBuffer(x *Xgress) *LinkSendBuffer {
 		windowsSize:       x.Options.TxPortalStartSize,
 		retxThreshold:     x.Options.RetxStartMs,
 		retxScale:         x.Options.RetxScale,
-		events:            make(chan sendBufferEvent, 1),
+		inspectRequests:   make(chan *sendBufferInspectEvent, 1),
 	}
 
 	return buffer
@@ -231,7 +229,6 @@ func (buffer *LinkSendBuffer) isBlocked() bool {
 func (buffer *LinkSendBuffer) run() {
 	log := pfxlog.ContextLogger(buffer.x.Label())
 	defer log.Debugf("[%p] exited", buffer)
-	defer buffer.drainDeadlines()
 	log.Debugf("[%p] started", buffer)
 
 	go buffer.retransmitSender()
@@ -274,21 +271,9 @@ func (buffer *LinkSendBuffer) run() {
 			}
 		}
 
-		rdCb := buffer.readDeadlineCb.Load()
-		wrCb := buffer.writeDeadlineCb.Load()
-
-		var rdTimer <-chan time.Time
-		var wrTimer <-chan time.Time
-		if rdCb != nil {
-			rdTimer = rdCb.C
-		}
-		if wrCb != nil {
-			wrTimer = wrCb.C
-		}
-
 		select {
-		case event := <-buffer.events:
-			event.handle(buffer)
+		case inspectEvent := <-buffer.inspectRequests:
+			inspectEvent.handle(buffer)
 
 		case ack := <-buffer.newlyReceivedAcks:
 			buffer.receiveAcknowledgement(ack)
@@ -307,12 +292,6 @@ func (buffer *LinkSendBuffer) run() {
 			buffer.retransmit()
 			buffer.checkForClose()
 
-		case <-rdTimer:
-			rdCb.fire()
-
-		case <-wrTimer:
-			wrCb.fire()
-
 		case <-buffer.closeNotify:
 			buffer.cleanupMetrics()
 			if len(buffer.buffer) > 0 {
@@ -326,36 +305,6 @@ func (buffer *LinkSendBuffer) run() {
 					log.WithField("payloadCount", len(buffer.buffer)).Warn("closing while buffer contains unacked payloads")
 				}
 			}
-			return
-		}
-	}
-}
-
-// drainDeadlines processes deadline timer callbacks after the send buffer has
-// closed but while the xgress is still alive. This handles the half-close case
-// where the write path is done but the read adapter still needs deadlines.
-func (buffer *LinkSendBuffer) drainDeadlines() {
-	for {
-		rdCb := buffer.readDeadlineCb.Load()
-		wrCb := buffer.writeDeadlineCb.Load()
-
-		var rdTimer <-chan time.Time
-		var wrTimer <-chan time.Time
-		if rdCb != nil {
-			rdTimer = rdCb.C
-		}
-		if wrCb != nil {
-			wrTimer = wrCb.C
-		}
-
-		select {
-		case <-rdTimer:
-			rdCb.fire()
-		case <-wrTimer:
-			wrCb.fire()
-		case event := <-buffer.events:
-			event.handle(buffer)
-		case <-buffer.x.closeNotify:
 			return
 		}
 	}
@@ -601,7 +550,7 @@ func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
 	}
 
 	select {
-	case buffer.events <- inspectEvent:
+	case buffer.inspectRequests <- inspectEvent:
 		select {
 		case result := <-inspectEvent.notifyComplete:
 			result.AcquiredSafely = true
@@ -616,12 +565,6 @@ func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
 	return result
 }
 
-// sendBufferEvent is processed by the LinkSendBuffer run loop. Implementations
-// include inspect requests and deadline wake signals.
-type sendBufferEvent interface {
-	handle(buffer *LinkSendBuffer)
-}
-
 type sendBufferInspectEvent struct {
 	notifyComplete chan *SendBufferDetail
 }
@@ -630,9 +573,3 @@ func (self *sendBufferInspectEvent) handle(buffer *LinkSendBuffer) {
 	result := buffer.inspect()
 	self.notifyComplete <- result
 }
-
-// deadlineWakeEvent is a no-op event that forces the run loop's select to
-// re-evaluate, picking up a newly registered deadline timer channel.
-type deadlineWakeEvent struct{}
-
-func (deadlineWakeEvent) handle(*LinkSendBuffer) {}

--- a/xgress/read_adapter.go
+++ b/xgress/read_adapter.go
@@ -34,7 +34,7 @@ func NewReadAdapter(x *Xgress) *ReadAdapter {
 	result := &ReadAdapter{
 		x: x,
 	}
-	result.init(&x.payloadBuffer.readDeadlineCb, x.payloadBuffer.events)
+	result.init()
 	return result
 }
 

--- a/xgress/read_adapter_test.go
+++ b/xgress/read_adapter_test.go
@@ -220,14 +220,14 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 	req := require.New(t)
 
 	// Close the send buffer (half-close: write side done, read side still active).
-	// The run loop transitions to drainDeadlines.
+	// The send-buffer run loop exits while the read half remains active.
 	x.payloadBuffer.Close()
 
-	// Give the run loop time to process the close and enter drainDeadlines
+	// Give the run loop time to process the close.
 	time.Sleep(10 * time.Millisecond)
 	req.True(x.payloadBuffer.IsClosed(), "send buffer should be closed")
 
-	// Setting a future read deadline should still fire via drainDeadlines
+	// The runtime timer must still fire after the send-buffer loop exits.
 	start := time.Now()
 	err := ra.SetReadDeadline(start.Add(250 * time.Millisecond))
 	req.NoError(err)
@@ -250,6 +250,37 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 
 	var readTimeout *ReadTimeout
 	req.True(errors.As(err, &readTimeout), "expected *ReadTimeout after half-close, got %T", err)
+}
+
+func TestLinkSendBufferRunExitsAfterHalfCloseWithoutReadAdapter(t *testing.T) {
+	closeNotify := make(chan struct{})
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+	defer x.Close()
+
+	runDone := make(chan struct{})
+	go func() {
+		x.payloadBuffer.run()
+		close(runDone)
+	}()
+
+	// A normal router xgress has no ReadAdapter. Closing its send half must
+	// stop the run goroutine even while the receive half remains open.
+	x.payloadBuffer.Close()
+
+	select {
+	case <-runDone:
+		require.False(t, x.IsClosed(), "only the send half should be closed")
+	case <-time.After(time.Second):
+		t.Fatal("link send buffer run goroutine did not exit after half-close")
+	}
 }
 
 func TestReadAdapterEOFOnClose(t *testing.T) {

--- a/xgress/write_adapter.go
+++ b/xgress/write_adapter.go
@@ -22,7 +22,7 @@ func NewWriteAdapter(x *Xgress) *WriteAdapter {
 	result := &WriteAdapter{
 		x: x,
 	}
-	result.init(&x.payloadBuffer.writeDeadlineCb, x.payloadBuffer.events)
+	result.init()
 	return result
 }
 


### PR DESCRIPTION
Fixes #987.

Related: openziti/ziti#4184.

`LinkSendBuffer.run` currently remains in `drainDeadlines` after its send half closes, retaining one goroutine for every half-closed xgress. This is unnecessary even for adapter deadlines: `time.AfterFunc` uses the runtime timer heap and only invokes its callback when the deadline fires.

This change:

- moves deadline delivery to `time.AfterFunc`
- removes `drainDeadlines`, the read/write callback slots, deadline wake events, and deadline select cases
- preserves synchronized deadline cancellation and reset behavior
- adds a regression test proving the normal send-buffer goroutine exits after half-close
- retains coverage proving read deadlines fire after the send half closes

Validation:

- `go test ./...`
- `go test -race ./xgress -run Test... -count=10` covering read/write deadlines, reset, half-close, and goroutine exit