### PR TITLE
[Backport-1.8] LinkSendBuffer leaks goroutines after send-half close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release notes 1.8.1
+
+## Issues Fixed and Dependency Updates
+
+* github.com/openziti/sdk-golang: [v1.8.0 -> v1.8.1](https://github.com/openziti/sdk-golang/compare/v1.8.0...v1.8.1)
+    * [Issue #988](https://github.com/openziti/sdk-golang/issues/988) - LinkSendBuffer leaks goroutines after send-half close
+    * [Issue #992](https://github.com/openziti/sdk-golang/issues/992) - Read deadline on ReadAdapter permanently closes the peer's send buffer
+
+
 # Release notes 1.8.0
 
 ## Issues Fixed and Dependency Updates

--- a/xgress/deadline.go
+++ b/xgress/deadline.go
@@ -18,65 +18,73 @@ package xgress
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/openziti/foundation/v2/concurrenz"
 )
 
-// deadlineCallback holds a timer channel and the function to call when it fires.
-// It is stored in an atomic slot on the LinkSendBuffer so that the run loop can
-// include the timer channel in its select without spawning extra goroutines.
-type deadlineCallback struct {
-	C    <-chan time.Time
-	fire func()
-}
-
 // deadlineControl manages a deadline with notification channel semantics.
 // When the deadline expires (or is set in the past), the Done channel is closed.
 // Clearing the deadline (zero time) resets the channel to a fresh open one.
 //
-// Future deadlines register a timer channel in the slot for processing by the
-// LinkSendBuffer run loop and send a wake event so the loop picks it up.
+// Future deadlines use the runtime timer heap. time.AfterFunc only starts a
+// goroutine when the deadline fires, so no persistent deadline goroutine is
+// needed while the timer is pending.
 type deadlineControl struct {
-	deadline         concurrenz.AtomicValue[time.Time]
-	doneNotify       concurrenz.AtomicValue[chan struct{}]
-	doneNotifyClosed bool
-	timer            *time.Timer
-	slot             *atomic.Pointer[deadlineCallback]
-	events           chan sendBufferEvent
-	lock             sync.Mutex
+	state *deadlineState
 }
 
-func (dc *deadlineControl) init(slot *atomic.Pointer[deadlineCallback], events chan sendBufferEvent) {
-	dc.doneNotify.Store(make(chan struct{}))
-	dc.slot = slot
-	dc.events = events
+func (dc *deadlineControl) init() {
+	state := &deadlineState{}
+	state.doneNotify.Store(make(chan struct{}))
+	dc.state = state
 }
 
 // Done returns a channel that is closed when the current deadline expires.
 func (dc *deadlineControl) Done() <-chan struct{} {
-	return dc.doneNotify.Load()
+	return dc.state.doneNotify.Load()
 }
 
 // SetDeadline sets the deadline to t. A zero value clears the deadline.
 func (dc *deadlineControl) SetDeadline(t time.Time) error {
-	dc.lock.Lock()
-	defer dc.lock.Unlock()
+	return dc.state.setDeadline(t)
+}
 
-	dc.deadline.Store(t)
+// currentDeadline returns the deadline in effect, or the zero time if none is set.
+func (dc *deadlineControl) currentDeadline() time.Time {
+	return dc.state.deadline.Load()
+}
+
+// deadlineState holds the mutable half of a deadline. It is a separate allocation so
+// that a pending timer callback retains only this, rather than the adapter embedding
+// deadlineControl and, through it, the whole Xgress. A pending timer is reachable from
+// the runtime timer heap until it fires, so anything its callback captures would
+// otherwise stay live for the full duration of the deadline even after the xgress is
+// closed and dropped.
+type deadlineState struct {
+	deadline         concurrenz.AtomicValue[time.Time]
+	doneNotify       concurrenz.AtomicValue[chan struct{}]
+	doneNotifyClosed bool
+	timer            *time.Timer
+	lock             sync.Mutex
+}
+
+func (st *deadlineState) setDeadline(t time.Time) error {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+
+	st.deadline.Store(t)
 
 	// Stop any existing timer
-	if dc.timer != nil {
-		dc.timer.Stop()
-		dc.timer = nil
+	if st.timer != nil {
+		st.timer.Stop()
+		st.timer = nil
 	}
-	dc.slot.Store(nil)
 
 	if t.IsZero() {
-		if dc.doneNotifyClosed {
-			dc.doneNotify.Store(make(chan struct{}))
-			dc.doneNotifyClosed = false
+		if st.doneNotifyClosed {
+			st.doneNotify.Store(make(chan struct{}))
+			st.doneNotifyClosed = false
 		}
 		return nil
 	}
@@ -84,40 +92,31 @@ func (dc *deadlineControl) SetDeadline(t time.Time) error {
 	d := time.Until(t)
 	if d <= 0 {
 		// Already expired — close immediately
-		if !dc.doneNotifyClosed {
-			close(dc.doneNotify.Load())
-			dc.doneNotifyClosed = true
+		if !st.doneNotifyClosed {
+			close(st.doneNotify.Load())
+			st.doneNotifyClosed = true
 		}
 		return nil
 	}
 
 	// Future deadline — reopen channel if needed
-	if dc.doneNotifyClosed {
-		dc.doneNotify.Store(make(chan struct{}))
-		dc.doneNotifyClosed = false
+	if st.doneNotifyClosed {
+		st.doneNotify.Store(make(chan struct{}))
+		st.doneNotifyClosed = false
 	}
 
-	dc.timer = time.NewTimer(d)
-	dc.slot.Store(&deadlineCallback{
-		C:    dc.timer.C,
-		fire: func() { dc.fireDeadline(t) },
-	})
-	// Wake the run loop so it re-evaluates with the new timer channel
-	select {
-	case dc.events <- deadlineWakeEvent{}:
-	default:
-	}
+	st.timer = time.AfterFunc(d, func() { st.fireDeadline(t) })
 
 	return nil
 }
 
 // fireDeadline closes the Done channel if the deadline hasn't changed since the
 // timer was created.
-func (dc *deadlineControl) fireDeadline(expectedDeadline time.Time) {
-	dc.lock.Lock()
-	defer dc.lock.Unlock()
-	if dc.deadline.Load().Equal(expectedDeadline) && !dc.doneNotifyClosed {
-		close(dc.doneNotify.Load())
-		dc.doneNotifyClosed = true
+func (st *deadlineState) fireDeadline(expectedDeadline time.Time) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.deadline.Load().Equal(expectedDeadline) && !st.doneNotifyClosed {
+		close(st.doneNotify.Load())
+		st.doneNotifyClosed = true
 	}
 }

--- a/xgress/deadline.go
+++ b/xgress/deadline.go
@@ -75,7 +75,9 @@ func (st *deadlineState) setDeadline(t time.Time) error {
 
 	st.deadline.Store(t)
 
-	// Stop any existing timer
+	// Stop any existing timer. The return value is ignored on purpose: a timer that
+	// already fired is blocked on our lock, and fireDeadline's expectedDeadline check
+	// below discards it once it gets in.
 	if st.timer != nil {
 		st.timer.Stop()
 		st.timer = nil

--- a/xgress/deadline_test.go
+++ b/xgress/deadline_test.go
@@ -1,0 +1,80 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// requireCollected drives the collector and fails if the tracked object is still live.
+func requireCollected(t *testing.T, collected <-chan struct{}, msg string) {
+	t.Helper()
+	for i := 0; i < 20; i++ {
+		runtime.GC()
+		select {
+		case <-collected:
+			return
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	t.Fatal(msg)
+}
+
+// TestPendingDeadlineDoesNotRetainXgress covers the lifetime of a deadline timer. A
+// pending timer stays reachable from the runtime timer heap until it fires, so its
+// callback must not capture the adapter: doing so would hold the xgress and its buffers
+// live for the whole deadline even after the caller has dropped them.
+func TestPendingDeadlineDoesNotRetainXgress(t *testing.T) {
+	for _, adapter := range []string{"read", "write"} {
+		t.Run(adapter, func(t *testing.T) {
+			closeNotify := make(chan struct{})
+			collected := make(chan struct{})
+
+			// Scoped so the xgress and adapter are unreachable once this returns.
+			func() {
+				conn := &testConn{
+					ch:          make(chan uint64, 1),
+					closeNotify: make(chan struct{}),
+				}
+
+				x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+				x.dataPlane = noopReceiveHandler{
+					payloadIngester: NewPayloadIngester(closeNotify),
+				}
+
+				runtime.AddCleanup(x, func(struct{}) { close(collected) }, struct{}{})
+
+				// A deadline far enough out that it cannot fire during the test.
+				if adapter == "read" {
+					ra := x.NewReadAdapter()
+					if err := ra.SetReadDeadline(time.Now().Add(time.Hour)); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					wa := x.NewWriteAdapter()
+					if err := wa.SetWriteDeadline(time.Now().Add(time.Hour)); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}()
+
+			requireCollected(t, collected, "xgress retained by a pending deadline timer")
+		})
+	}
+}

--- a/xgress/deadline_test.go
+++ b/xgress/deadline_test.go
@@ -78,3 +78,61 @@ func TestPendingDeadlineDoesNotRetainXgress(t *testing.T) {
 		})
 	}
 }
+
+// newDeadlineBenchXgress builds an xgress with a running send buffer and a no-op close
+// handler, so tearing it down doesn't log a warning into the benchmark output.
+func newDeadlineBenchXgress(b *testing.B) *Xgress {
+	closeNotify := make(chan struct{})
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("bench", "ctrl", "bench", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+	x.AddCloseHandler(CloseHandlerF(func(*Xgress) {}))
+
+	go x.payloadBuffer.run()
+	b.Cleanup(x.Close)
+
+	return x
+}
+
+// BenchmarkSetReadDeadline measures the cost of arming a deadline. Deadlines are driven by
+// the runtime timer heap rather than by channels the send buffer's run loop selects on, so
+// this is the whole per-call cost; the old scheme also charged the run loop a wake event and
+// a select re-evaluation that a benchmark on this goroutine would not see.
+func BenchmarkSetReadDeadline(b *testing.B) {
+	ra := newDeadlineBenchXgress(b).NewReadAdapter()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ra.SetReadDeadline(time.Now().Add(time.Minute))
+	}
+}
+
+// BenchmarkSetReadDeadlineSetClear measures arm-then-disarm, the shape an application
+// timeout loop produces.
+func BenchmarkSetReadDeadlineSetClear(b *testing.B) {
+	ra := newDeadlineBenchXgress(b).NewReadAdapter()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ra.SetReadDeadline(time.Now().Add(time.Minute))
+		_ = ra.SetReadDeadline(time.Time{})
+	}
+}
+
+func BenchmarkSetWriteDeadline(b *testing.B) {
+	wa := newDeadlineBenchXgress(b).NewWriteAdapter()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = wa.SetWriteDeadline(time.Now().Add(time.Minute))
+	}
+}

--- a/xgress/link_send_buffer.go
+++ b/xgress/link_send_buffer.go
@@ -57,9 +57,7 @@ type LinkSendBuffer struct {
 	lastRtt               uint16
 	lastRetransmitTime    int64
 	closeWhenEmpty        atomic.Bool
-	events                chan sendBufferEvent
-	readDeadlineCb        atomic.Pointer[deadlineCallback]
-	writeDeadlineCb       atomic.Pointer[deadlineCallback]
+	inspectRequests       chan *sendBufferInspectEvent
 	blockedSince          time.Time
 	closeStart            time.Time
 }
@@ -119,7 +117,7 @@ func NewLinkSendBuffer(x *Xgress) *LinkSendBuffer {
 		windowsSize:       x.Options.TxPortalStartSize,
 		retxThreshold:     x.Options.RetxStartMs,
 		retxScale:         x.Options.RetxScale,
-		events:            make(chan sendBufferEvent, 1),
+		inspectRequests:   make(chan *sendBufferInspectEvent, 1),
 	}
 
 	return buffer
@@ -231,7 +229,6 @@ func (buffer *LinkSendBuffer) isBlocked() bool {
 func (buffer *LinkSendBuffer) run() {
 	log := pfxlog.ContextLogger(buffer.x.Label())
 	defer log.Debugf("[%p] exited", buffer)
-	defer buffer.drainDeadlines()
 	log.Debugf("[%p] started", buffer)
 
 	go buffer.retransmitSender()
@@ -274,21 +271,9 @@ func (buffer *LinkSendBuffer) run() {
 			}
 		}
 
-		rdCb := buffer.readDeadlineCb.Load()
-		wrCb := buffer.writeDeadlineCb.Load()
-
-		var rdTimer <-chan time.Time
-		var wrTimer <-chan time.Time
-		if rdCb != nil {
-			rdTimer = rdCb.C
-		}
-		if wrCb != nil {
-			wrTimer = wrCb.C
-		}
-
 		select {
-		case event := <-buffer.events:
-			event.handle(buffer)
+		case inspectEvent := <-buffer.inspectRequests:
+			inspectEvent.handle(buffer)
 
 		case ack := <-buffer.newlyReceivedAcks:
 			buffer.receiveAcknowledgement(ack)
@@ -307,12 +292,6 @@ func (buffer *LinkSendBuffer) run() {
 			buffer.retransmit()
 			buffer.checkForClose()
 
-		case <-rdTimer:
-			rdCb.fire()
-
-		case <-wrTimer:
-			wrCb.fire()
-
 		case <-buffer.closeNotify:
 			buffer.cleanupMetrics()
 			if len(buffer.buffer) > 0 {
@@ -326,36 +305,6 @@ func (buffer *LinkSendBuffer) run() {
 					log.WithField("payloadCount", len(buffer.buffer)).Warn("closing while buffer contains unacked payloads")
 				}
 			}
-			return
-		}
-	}
-}
-
-// drainDeadlines processes deadline timer callbacks after the send buffer has
-// closed but while the xgress is still alive. This handles the half-close case
-// where the write path is done but the read adapter still needs deadlines.
-func (buffer *LinkSendBuffer) drainDeadlines() {
-	for {
-		rdCb := buffer.readDeadlineCb.Load()
-		wrCb := buffer.writeDeadlineCb.Load()
-
-		var rdTimer <-chan time.Time
-		var wrTimer <-chan time.Time
-		if rdCb != nil {
-			rdTimer = rdCb.C
-		}
-		if wrCb != nil {
-			wrTimer = wrCb.C
-		}
-
-		select {
-		case <-rdTimer:
-			rdCb.fire()
-		case <-wrTimer:
-			wrCb.fire()
-		case event := <-buffer.events:
-			event.handle(buffer)
-		case <-buffer.x.closeNotify:
 			return
 		}
 	}
@@ -601,7 +550,7 @@ func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
 	}
 
 	select {
-	case buffer.events <- inspectEvent:
+	case buffer.inspectRequests <- inspectEvent:
 		select {
 		case result := <-inspectEvent.notifyComplete:
 			result.AcquiredSafely = true
@@ -616,12 +565,6 @@ func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
 	return result
 }
 
-// sendBufferEvent is processed by the LinkSendBuffer run loop. Implementations
-// include inspect requests and deadline wake signals.
-type sendBufferEvent interface {
-	handle(buffer *LinkSendBuffer)
-}
-
 type sendBufferInspectEvent struct {
 	notifyComplete chan *SendBufferDetail
 }
@@ -630,9 +573,3 @@ func (self *sendBufferInspectEvent) handle(buffer *LinkSendBuffer) {
 	result := buffer.inspect()
 	self.notifyComplete <- result
 }
-
-// deadlineWakeEvent is a no-op event that forces the run loop's select to
-// re-evaluate, picking up a newly registered deadline timer channel.
-type deadlineWakeEvent struct{}
-
-func (deadlineWakeEvent) handle(*LinkSendBuffer) {}

--- a/xgress/link_send_buffer.go
+++ b/xgress/link_send_buffer.go
@@ -58,6 +58,7 @@ type LinkSendBuffer struct {
 	lastRetransmitTime    int64
 	closeWhenEmpty        atomic.Bool
 	inspectRequests       chan *sendBufferInspectEvent
+	runExited             chan struct{}
 	blockedSince          time.Time
 	closeStart            time.Time
 }
@@ -118,6 +119,7 @@ func NewLinkSendBuffer(x *Xgress) *LinkSendBuffer {
 		retxThreshold:     x.Options.RetxStartMs,
 		retxScale:         x.Options.RetxScale,
 		inspectRequests:   make(chan *sendBufferInspectEvent, 1),
+		runExited:         make(chan struct{}),
 	}
 
 	return buffer
@@ -228,6 +230,9 @@ func (buffer *LinkSendBuffer) isBlocked() bool {
 
 func (buffer *LinkSendBuffer) run() {
 	log := pfxlog.ContextLogger(buffer.x.Label())
+	// Registered first so it runs last: once this closes, no goroutine mutates the
+	// fields Inspect reads.
+	defer close(buffer.runExited)
 	defer log.Debugf("[%p] exited", buffer)
 	log.Debugf("[%p] started", buffer)
 
@@ -543,7 +548,19 @@ func (buffer *LinkSendBuffer) inspect() *SendBufferDetail {
 	return result
 }
 
+// Inspect returns a snapshot of the send buffer's state. It normally hands the request to
+// the run loop so the fields are read from the goroutine that owns them. Once the run loop
+// has exited there is nobody to service that request and nobody left to mutate the fields,
+// so the snapshot is taken directly.
 func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
+	select {
+	case <-buffer.runExited:
+		result := buffer.inspect()
+		result.AcquiredSafely = true
+		return result
+	default:
+	}
+
 	timeout := time.After(100 * time.Millisecond)
 	inspectEvent := &sendBufferInspectEvent{
 		notifyComplete: make(chan *SendBufferDetail, 1),
@@ -559,6 +576,10 @@ func (buffer *LinkSendBuffer) Inspect() *SendBufferDetail {
 		}
 	case <-timeout:
 	}
+
+	// The run loop is alive but didn't answer in time, so the snapshot below is read
+	// without synchronization and may be inconsistent.
+	pfxlog.ContextLogger(buffer.x.Label()).Debug("send buffer inspect timed out, reporting unsynchronized state")
 
 	result := buffer.inspect()
 	result.AcquiredSafely = false

--- a/xgress/link_send_buffer_test.go
+++ b/xgress/link_send_buffer_test.go
@@ -1,0 +1,99 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package xgress
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinkSendBufferRunExitsAfterHalfClose covers the send-half close of an xgress with no
+// adapters, which is what every router xgress looks like. The run goroutine must exit even
+// though the receive half, and so the xgress itself, is still open.
+func TestLinkSendBufferRunExitsAfterHalfClose(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+	defer x.Close()
+
+	go x.payloadBuffer.run()
+
+	x.payloadBuffer.Close()
+
+	select {
+	case <-x.payloadBuffer.runExited:
+		req.False(x.IsClosed(), "only the send half should be closed")
+	case <-time.After(time.Second):
+		req.Fail("link send buffer run goroutine did not exit after half-close")
+	}
+}
+
+// TestInspectAfterRunExited covers inspecting a send buffer whose run loop is gone. Nothing
+// is left to service the handoff, so Inspect must read the state directly rather than
+// waiting out its timeout and reporting an unsynchronized snapshot.
+func TestInspectAfterRunExited(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+	defer x.Close()
+
+	go x.payloadBuffer.run()
+
+	detail := x.payloadBuffer.Inspect()
+	req.True(detail.AcquiredSafely, "inspect should be serviced by a live run loop")
+	req.False(detail.Closed)
+
+	x.payloadBuffer.Close()
+
+	select {
+	case <-x.payloadBuffer.runExited:
+	case <-time.After(time.Second):
+		req.Fail("send buffer run loop did not exit after half-close")
+	}
+
+	// Repeated so a request left parked in the handoff channel by an earlier call would
+	// show up as a timeout on a later one.
+	for i := 0; i < 3; i++ {
+		start := time.Now()
+		detail = x.payloadBuffer.Inspect()
+		elapsed := time.Since(start)
+
+		req.True(detail.AcquiredSafely, "inspect %v should be read directly once run has exited", i)
+		req.True(detail.Closed, "inspect %v should report the buffer closed", i)
+		req.Less(elapsed, 50*time.Millisecond, "inspect %v waited out the handoff timeout (%s)", i, elapsed)
+	}
+}

--- a/xgress/read_adapter.go
+++ b/xgress/read_adapter.go
@@ -34,7 +34,7 @@ func NewReadAdapter(x *Xgress) *ReadAdapter {
 	result := &ReadAdapter{
 		x: x,
 	}
-	result.init(&x.payloadBuffer.readDeadlineCb, x.payloadBuffer.events)
+	result.init()
 	return result
 }
 

--- a/xgress/read_adapter.go
+++ b/xgress/read_adapter.go
@@ -17,6 +17,7 @@
 package xgress
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
 )
@@ -52,6 +53,7 @@ func (self *ReadAdapter) SetReadDeadline(t time.Time) error {
 	return self.SetDeadline(t)
 }
 
+// cleanup runs the tx-side teardown once, when the fabric-to-app half is finished.
 func (self *ReadAdapter) cleanup() {
 	if self.cleanedUp.CompareAndSwap(false, true) {
 		self.x.txCleanup()
@@ -64,7 +66,13 @@ func (self *ReadAdapter) cleanup() {
 func (self *ReadAdapter) ReadPayload() ([]byte, map[uint8][]byte, error) {
 	data, headers, err := self.x.nextTxPayload(self.Done())
 	if err != nil {
-		self.cleanup()
+		// A deadline is recoverable and the caller may read again, so it must not run
+		// the tx-side teardown. Doing so tells the peer this half is finished, which
+		// closes the peer's send buffer for good and wedges the circuit.
+		var readTimeout *ReadTimeout
+		if !errors.As(err, &readTimeout) {
+			self.cleanup()
+		}
 		return nil, nil, err
 	}
 	return data, headers, nil

--- a/xgress/read_adapter_test.go
+++ b/xgress/read_adapter_test.go
@@ -223,8 +223,11 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 	// The send-buffer run loop exits while the read half remains active.
 	x.payloadBuffer.Close()
 
-	// Give the run loop time to process the close.
-	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-x.payloadBuffer.runExited:
+	case <-time.After(time.Second):
+		req.Fail("send buffer run loop did not exit after half-close")
+	}
 	req.True(x.payloadBuffer.IsClosed(), "send buffer should be closed")
 
 	// The runtime timer must still fire after the send-buffer loop exits.
@@ -250,37 +253,6 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 
 	var readTimeout *ReadTimeout
 	req.True(errors.As(err, &readTimeout), "expected *ReadTimeout after half-close, got %T", err)
-}
-
-func TestLinkSendBufferRunExitsAfterHalfCloseWithoutReadAdapter(t *testing.T) {
-	closeNotify := make(chan struct{})
-	conn := &testConn{
-		ch:          make(chan uint64, 1),
-		closeNotify: make(chan struct{}),
-	}
-
-	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
-	x.dataPlane = noopReceiveHandler{
-		payloadIngester: NewPayloadIngester(closeNotify),
-	}
-	defer x.Close()
-
-	runDone := make(chan struct{})
-	go func() {
-		x.payloadBuffer.run()
-		close(runDone)
-	}()
-
-	// A normal router xgress has no ReadAdapter. Closing its send half must
-	// stop the run goroutine even while the receive half remains open.
-	x.payloadBuffer.Close()
-
-	select {
-	case <-runDone:
-		require.False(t, x.IsClosed(), "only the send half should be closed")
-	case <-time.After(time.Second):
-		t.Fatal("link send buffer run goroutine did not exit after half-close")
-	}
 }
 
 func TestReadAdapterEOFOnClose(t *testing.T) {
@@ -400,6 +372,49 @@ func TestReadAdapterDeadlineDoesNotCloseWriteHalf(t *testing.T) {
 	recvAndVerifyPayloads(t, req, 3, tc.srcRA, nil)
 }
 
+// TestReadAdapterDeadlineSetWhileBlocked covers the net.Conn contract that a deadline set
+// after a read is already blocked still applies to that read. ReadPayload captures Done()
+// once on entry, so the channel it holds has to be the one the later deadline closes.
+func TestReadAdapterDeadlineSetWhileBlocked(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	ra := x.NewReadAdapter()
+	go x.payloadBuffer.run()
+	defer x.Close()
+
+	// No deadline yet, and nothing queued, so this parks.
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := ra.ReadPayload()
+		readErr <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	req.NoError(ra.SetReadDeadline(start.Add(50 * time.Millisecond)))
+
+	select {
+	case err := <-readErr:
+		var readTimeout *ReadTimeout
+		req.True(errors.As(err, &readTimeout), "expected *ReadTimeout, got %T", err)
+		req.True(time.Since(start) >= 50*time.Millisecond, "read returned before the deadline")
+	case <-time.After(5 * time.Second):
+		req.Fail("blocked read never observed a deadline set after it started")
+	}
+}
+
 // TestReadAdapterDeadlineConcurrent covers deadlines set and cleared from another
 // goroutine, mirroring the concurrent cases in TestWriteTimeout.
 func TestReadAdapterDeadlineConcurrent(t *testing.T) {
@@ -464,7 +479,24 @@ func TestReadAdapterDeadlineConcurrent(t *testing.T) {
 		// expected
 	}
 
+	// a superseded timer must not fire on its own schedule
+	req.NoError(ra.SetReadDeadline(time.Time{}))
+	start = time.Now()
+	req.NoError(ra.SetReadDeadline(start.Add(20 * time.Millisecond)))
+	time.Sleep(5 * time.Millisecond)
+	req.NoError(ra.SetReadDeadline(start.Add(300 * time.Millisecond)))
+
+	select {
+	case <-ra.Done():
+		passed := time.Since(start)
+		req.True(passed >= 300*time.Millisecond,
+			"superseded 20ms deadline fired instead of the 300ms one, after %s", passed)
+	case <-time.After(2 * time.Second):
+		req.Fail("timeout didn't fire")
+	}
+
 	// deadline moved into the past asynchronously
+	req.NoError(ra.SetReadDeadline(time.Time{}))
 	start = time.Now()
 	req.NoError(ra.SetReadDeadline(time.Now().Add(time.Hour)))
 	go func() {

--- a/xgress/read_adapter_test.go
+++ b/xgress/read_adapter_test.go
@@ -363,6 +363,43 @@ func TestReadAdapterDeadlineDoesNotDisturbStream(t *testing.T) {
 	}
 }
 
+// TestReadAdapterDeadlineDoesNotCloseWriteHalf covers a read deadline expiring on a live
+// circuit. A deadline is recoverable, so it must not run the tx-side teardown: that sends
+// a write-failed payload, which closes the peer's send buffer permanently and leaves the
+// circuit unable to deliver anything further.
+func TestReadAdapterDeadlineDoesNotCloseWriteHalf(t *testing.T) {
+	req := require.New(t)
+
+	tc := newTestCircuit(modeReadAdapter)
+	defer tc.cleanup()
+
+	// let the circuit-start and capabilities exchange settle
+	time.Sleep(50 * time.Millisecond)
+
+	req.NoError(tc.srcRA.SetReadDeadline(time.Now().Add(50 * time.Millisecond)))
+
+	_, _, err := tc.srcRA.ReadPayload()
+	var readTimeout *ReadTimeout
+	req.True(errors.As(err, &readTimeout), "expected *ReadTimeout, got %T", err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	req.False(tc.dst.payloadBuffer.IsClosed(), "read deadline closed the peer's send buffer")
+
+	select {
+	case <-tc.srcConn.txClosedCh:
+		req.Fail("read deadline signaled fabric-to-xgress close")
+	default:
+	}
+
+	// The circuit must still carry data in the direction that timed out. Use a generous
+	// deadline rather than clearing it, so a wedged circuit fails the read instead of
+	// hanging the test.
+	req.NoError(tc.srcRA.SetReadDeadline(time.Now().Add(10 * time.Second)))
+	go sendPayloads(t, 3, nil, tc.dstConn.rxCh)
+	recvAndVerifyPayloads(t, req, 3, tc.srcRA, nil)
+}
+
 // TestReadAdapterDeadlineConcurrent covers deadlines set and cleared from another
 // goroutine, mirroring the concurrent cases in TestWriteTimeout.
 func TestReadAdapterDeadlineConcurrent(t *testing.T) {

--- a/xgress/read_adapter_test.go
+++ b/xgress/read_adapter_test.go
@@ -220,14 +220,14 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 	req := require.New(t)
 
 	// Close the send buffer (half-close: write side done, read side still active).
-	// The run loop transitions to drainDeadlines.
+	// The send-buffer run loop exits while the read half remains active.
 	x.payloadBuffer.Close()
 
-	// Give the run loop time to process the close and enter drainDeadlines
+	// Give the run loop time to process the close.
 	time.Sleep(10 * time.Millisecond)
 	req.True(x.payloadBuffer.IsClosed(), "send buffer should be closed")
 
-	// Setting a future read deadline should still fire via drainDeadlines
+	// The runtime timer must still fire after the send-buffer loop exits.
 	start := time.Now()
 	err := ra.SetReadDeadline(start.Add(250 * time.Millisecond))
 	req.NoError(err)
@@ -250,6 +250,37 @@ func TestReadAdapterDeadlineAfterHalfClose(t *testing.T) {
 
 	var readTimeout *ReadTimeout
 	req.True(errors.As(err, &readTimeout), "expected *ReadTimeout after half-close, got %T", err)
+}
+
+func TestLinkSendBufferRunExitsAfterHalfCloseWithoutReadAdapter(t *testing.T) {
+	closeNotify := make(chan struct{})
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+	defer x.Close()
+
+	runDone := make(chan struct{})
+	go func() {
+		x.payloadBuffer.run()
+		close(runDone)
+	}()
+
+	// A normal router xgress has no ReadAdapter. Closing its send half must
+	// stop the run goroutine even while the receive half remains open.
+	x.payloadBuffer.Close()
+
+	select {
+	case <-runDone:
+		require.False(t, x.IsClosed(), "only the send half should be closed")
+	case <-time.After(time.Second):
+		t.Fatal("link send buffer run goroutine did not exit after half-close")
+	}
 }
 
 func TestReadAdapterEOFOnClose(t *testing.T) {
@@ -278,4 +309,136 @@ func TestReadAdapterEOFOnClose(t *testing.T) {
 
 	_, _, err := ra.ReadPayload()
 	req.ErrorIs(err, io.EOF)
+}
+
+// TestReadAdapterDeadlineDoesNotDisturbStream verifies that a read deadline expiring
+// with nothing queued neither consumes nor reorders subsequently delivered payloads.
+func TestReadAdapterDeadlineDoesNotDisturbStream(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	ra := x.NewReadAdapter()
+
+	// The send buffer loop must be running: a ReadPayload error runs txCleanup, which
+	// buffers a write-failed payload and would otherwise block on newlyBuffered.
+	go x.payloadBuffer.run()
+	defer x.Close()
+
+	req.NoError(ra.SetReadDeadline(time.Now().Add(50 * time.Millisecond)))
+
+	_, _, err := ra.ReadPayload()
+	var readTimeout *ReadTimeout
+	req.True(errors.As(err, &readTimeout), "expected *ReadTimeout, got %T", err)
+
+	// Done() stays closed after firing, so the deadline must be cleared before the
+	// stream is readable again.
+	req.NoError(ra.SetReadDeadline(time.Time{}))
+
+	const payloadCount = 3
+	for i := 0; i < payloadCount; i++ {
+		data := make([]byte, 8)
+		binary.LittleEndian.PutUint64(data, uint64(i))
+		req.NoError(x.SendPayload(&Payload{
+			CircuitId: "test",
+			Flags:     SetOriginatorFlag(0, Terminator),
+			Sequence:  int32(i),
+			Data:      data,
+		}, 0, PayloadTypeXg))
+	}
+
+	for i := 0; i < payloadCount; i++ {
+		data, _, err := ra.ReadPayload()
+		req.NoError(err)
+		req.Equal(uint64(i), binary.LittleEndian.Uint64(data), "payload %v out of order", i)
+	}
+}
+
+// TestReadAdapterDeadlineConcurrent covers deadlines set and cleared from another
+// goroutine, mirroring the concurrent cases in TestWriteTimeout.
+func TestReadAdapterDeadlineConcurrent(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	ra := x.NewReadAdapter()
+	go x.payloadBuffer.run()
+	defer x.Close()
+
+	// deadline set asynchronously
+	start := time.Now()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		req.NoError(ra.SetReadDeadline(time.Now().Add(200 * time.Millisecond)))
+	}()
+
+	select {
+	case <-ra.Done():
+		passed := time.Since(start)
+		req.True(passed >= 300*time.Millisecond, "expected at least 300ms, got %s", passed)
+	case <-time.After(2 * time.Second):
+		req.Fail("timeout didn't fire")
+	}
+
+	// pending deadline cleared asynchronously
+	req.NoError(ra.SetReadDeadline(time.Time{}))
+	req.NoError(ra.SetReadDeadline(time.Now().Add(250 * time.Millisecond)))
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		req.NoError(ra.SetReadDeadline(time.Time{}))
+	}()
+
+	select {
+	case <-ra.Done():
+		req.Fail("timeout should not have fired after the deadline was cleared")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	// deadline set and cleared, both asynchronously
+	go func() {
+		req.NoError(ra.SetReadDeadline(time.Now().Add(250 * time.Millisecond)))
+		time.Sleep(100 * time.Millisecond)
+		req.NoError(ra.SetReadDeadline(time.Time{}))
+	}()
+
+	select {
+	case <-ra.Done():
+		req.Fail("timeout should not have fired after the deadline was cleared")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	// deadline moved into the past asynchronously
+	start = time.Now()
+	req.NoError(ra.SetReadDeadline(time.Now().Add(time.Hour)))
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		req.NoError(ra.SetReadDeadline(time.Now().Add(-250 * time.Millisecond)))
+	}()
+
+	select {
+	case <-ra.Done():
+	case <-time.After(2 * time.Second):
+		req.Fail("timeout didn't fire")
+	}
+	req.True(time.Since(start) < time.Second, "past deadline should fire promptly")
 }

--- a/xgress/write_adapter.go
+++ b/xgress/write_adapter.go
@@ -22,7 +22,7 @@ func NewWriteAdapter(x *Xgress) *WriteAdapter {
 	result := &WriteAdapter{
 		x: x,
 	}
-	result.init(&x.payloadBuffer.writeDeadlineCb, x.payloadBuffer.events)
+	result.init()
 	return result
 }
 
@@ -32,7 +32,7 @@ type WriteAdapter struct {
 }
 
 func (self *WriteAdapter) Deadline() (deadline time.Time, ok bool) {
-	deadline = self.deadline.Load()
+	deadline = self.currentDeadline()
 	return deadline, !deadline.IsZero()
 }
 

--- a/xgress/write_adapter_test.go
+++ b/xgress/write_adapter_test.go
@@ -272,8 +272,8 @@ func TestWriteAdapterDeadlineWrite(t *testing.T) {
 
 	wa := x.NewWriteAdapter()
 
-	// Use a past deadline so Done() closes immediately in SetDeadline,
-	// without requiring the LinkSendBuffer run loop.
+	// A past deadline closes Done() synchronously inside SetDeadline, so no timer is
+	// involved. TestWriteAdapterDeadlineWhileWindowBlocked covers the timer path.
 	err := wa.SetWriteDeadline(time.Now().Add(-1 * time.Millisecond))
 	req.NoError(err)
 
@@ -305,4 +305,227 @@ func TestWriteAdapterCloseError(t *testing.T) {
 
 	_, writeErr := wa.Write([]byte("hello"))
 	req.ErrorIs(writeErr, ErrWriteClosed)
+}
+
+// TestWriteAdapterDeadlineAfterHalfClose is the write-side counterpart to
+// TestReadAdapterDeadlineAfterHalfClose. Closing the send half stops the send buffer's
+// run loop, and a write deadline registered afterward must still fire.
+func TestWriteAdapterDeadlineAfterHalfClose(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	wa := x.NewWriteAdapter()
+	go x.payloadBuffer.run()
+	defer x.Close()
+
+	// Half-close: the send half is done, the xgress as a whole is still alive.
+	x.payloadBuffer.Close()
+	req.True(x.payloadBuffer.IsClosed(), "send buffer should be closed")
+	req.False(x.IsClosed(), "only the send half should be closed")
+
+	// Let the run loop observe the close and exit, so the deadline below cannot be
+	// serviced by the loop.
+	time.Sleep(10 * time.Millisecond)
+
+	start := time.Now()
+	req.NoError(wa.SetWriteDeadline(start.Add(250 * time.Millisecond)))
+
+	select {
+	case <-wa.Done():
+		passed := time.Since(start)
+		req.True(passed >= 250*time.Millisecond, "expected at least 250ms, got %s", passed)
+	case <-time.After(2 * time.Second):
+		req.Fail("write deadline didn't fire after half-close")
+	}
+}
+
+// TestWriteAdapterDeadlineWhileWindowBlocked exercises the write-deadline path end to
+// end: Write blocks because the send window is full, the deadline expires, and
+// BufferPayloadWithDeadline surfaces os.ErrDeadlineExceeded.
+func TestWriteAdapterDeadlineWhileWindowBlocked(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	// A tiny send window lets a single unacked payload block the buffer.
+	// noopReceiveHandler never acks, so once blocked it stays blocked.
+	options := DefaultOptions()
+	options.TxPortalStartSize = 64
+	options.TxPortalMinSize = 64
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, options, nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	wa := x.NewWriteAdapter()
+	go x.payloadBuffer.run()
+	defer x.Close()
+
+	// Generous deadline on the priming write so an unexpected block fails rather than hangs.
+	req.NoError(wa.SetWriteDeadline(time.Now().Add(5 * time.Second)))
+	_, err := wa.Write(make([]byte, 128))
+	req.NoError(err)
+
+	req.Eventually(func() bool {
+		return x.payloadBuffer.Inspect().BlockedByLocalWindow
+	}, 5*time.Second, 5*time.Millisecond, "send buffer should block once the window is full")
+
+	start := time.Now()
+	req.NoError(wa.SetWriteDeadline(start.Add(100 * time.Millisecond)))
+
+	_, err = wa.Write([]byte("blocked"))
+	req.ErrorIs(err, os.ErrDeadlineExceeded)
+	req.True(time.Since(start) >= 100*time.Millisecond, "write returned before the deadline")
+}
+
+// blockWriteAdapterWindow returns an xgress whose send window is full, so the next
+// Write parks in BufferPayloadWithDeadline, along with its write adapter and the
+// sequence of the single unacked payload holding the window.
+func blockWriteAdapterWindow(t *testing.T, req *require.Assertions) (*Xgress, *WriteAdapter, int32) {
+	closeNotify := make(chan struct{})
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	options := DefaultOptions()
+	options.TxPortalStartSize = 64
+	options.TxPortalMinSize = 64
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, options, nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	wa := x.NewWriteAdapter()
+	go x.payloadBuffer.run()
+	t.Cleanup(x.Close)
+
+	// The priming payload takes the first sequence and fills the window on its own.
+	seq := int32(x.GetSequence())
+	req.NoError(wa.SetWriteDeadline(time.Now().Add(5 * time.Second)))
+	_, err := wa.Write(make([]byte, 128))
+	req.NoError(err)
+
+	req.Eventually(func() bool {
+		return x.payloadBuffer.Inspect().BlockedByLocalWindow
+	}, 5*time.Second, 5*time.Millisecond, "send buffer should block once the window is full")
+
+	return x, wa, seq
+}
+
+// TestWriteAdapterDeadlineClearedWhileBlocked verifies that clearing a deadline while a
+// Write is parked cancels the timeout: the write survives the original deadline instant
+// and completes once the send window reopens.
+func TestWriteAdapterDeadlineClearedWhileBlocked(t *testing.T) {
+	req := require.New(t)
+	x, wa, seq := blockWriteAdapterWindow(t, req)
+
+	start := time.Now()
+	req.NoError(wa.SetWriteDeadline(start.Add(100 * time.Millisecond)))
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := wa.Write([]byte("blocked"))
+		writeErr <- err
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	req.NoError(wa.SetWriteDeadline(time.Time{}))
+
+	// Reopen the window only after the original deadline has passed, so a completed
+	// write proves the cleared deadline never fired.
+	time.Sleep(150 * time.Millisecond)
+	ack := NewAcknowledgement("test", Terminator)
+	ack.Sequence = []int32{seq}
+	req.NoError(x.SendAcknowledgement(ack))
+
+	select {
+	case err := <-writeErr:
+		req.NoError(err)
+		req.True(time.Since(start) >= 100*time.Millisecond, "write completed before the original deadline")
+	case <-time.After(5 * time.Second):
+		req.Fail("write never completed after the deadline was cleared")
+	}
+}
+
+// TestWriteAdapterDeadlineExtendedWhileBlocked verifies that extending a deadline while a
+// Write is parked moves the timeout out rather than leaving the original in place.
+func TestWriteAdapterDeadlineExtendedWhileBlocked(t *testing.T) {
+	req := require.New(t)
+	_, wa, _ := blockWriteAdapterWindow(t, req)
+
+	start := time.Now()
+	req.NoError(wa.SetWriteDeadline(start.Add(100 * time.Millisecond)))
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := wa.Write([]byte("blocked"))
+		writeErr <- err
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	req.NoError(wa.SetWriteDeadline(start.Add(400 * time.Millisecond)))
+
+	select {
+	case err := <-writeErr:
+		req.ErrorIs(err, os.ErrDeadlineExceeded)
+		req.True(time.Since(start) >= 400*time.Millisecond,
+			"write timed out on the original deadline, not the extended one")
+	case <-time.After(5 * time.Second):
+		req.Fail("extended deadline never fired")
+	}
+}
+
+// TestWriteAdapterContext covers the context.Context surface WriteAdapter exposes, which
+// forwardPayloadImpl relies on to route writes through BufferPayloadWithDeadline.
+func TestWriteAdapterContext(t *testing.T) {
+	closeNotify := make(chan struct{})
+	req := require.New(t)
+
+	conn := &testConn{
+		ch:          make(chan uint64, 1),
+		closeNotify: make(chan struct{}),
+	}
+
+	x := NewXgress("test", "ctrl", "test", conn, Initiator, DefaultOptions(), nil)
+	x.dataPlane = noopReceiveHandler{
+		payloadIngester: NewPayloadIngester(closeNotify),
+	}
+
+	wa := x.NewWriteAdapter()
+
+	deadline, ok := wa.Deadline()
+	req.False(ok, "no deadline should be reported before one is set")
+	req.True(deadline.IsZero())
+
+	expected := time.Now().Add(time.Minute)
+	req.NoError(wa.SetWriteDeadline(expected))
+	deadline, ok = wa.Deadline()
+	req.True(ok)
+	req.True(expected.Equal(deadline), "expected %s, got %s", expected, deadline)
+
+	req.NoError(wa.SetWriteDeadline(time.Time{}))
+	deadline, ok = wa.Deadline()
+	req.False(ok, "cleared deadline should no longer be reported")
+	req.True(deadline.IsZero())
+
+	req.NoError(wa.Err())
+	req.Nil(wa.Value("anything"))
 }

--- a/ziti/sdkinfo/build_info.go
+++ b/ziti/sdkinfo/build_info.go
@@ -20,5 +20,5 @@
 package sdkinfo
 
 const (
-	Version   = "v1.8.0"
+	Version   = "v1.8.1"
 )


### PR DESCRIPTION
Fixes #988.

Backport of #989 to the SDK v1.8.x maintenance line.

Ziti `release-v2.0.x` remains on channel/v4 and cannot consume SDK v1.9, which migrated to channel/v5. This backport is based on SDK v1.8.0, the newest channel/v4-compatible release.

The code and regression coverage match the primary fix:

- deadline delivery uses `time.AfterFunc`
- `drainDeadlines` and its callback-slot/wake-event plumbing are removed
- the normal send-buffer goroutine exits after half-close
- read deadlines continue to fire after the send half closes

Validation:

- `go test ./...`
- `go test -race ./xgress -run Test... -count=10` covering read/write deadlines, reset, half-close, and goroutine exit