### PR TITLE
Add WithPlatform option to acquire for cross-platform acquisition

### DIFF
--- a/acceptance-tests.md
+++ b/acceptance-tests.md
@@ -97,9 +97,10 @@ ever served under a stable key like `ziti-connect-v2`. The resolution is a light
 remote call (GH API / `git ls-remote`); only the download or build is skipped on a cache
 hit. The selector -> resolved-id mapping is logged each run for version attribution.
 
-Cache resolved binaries under e.g. `~/.cache/ziti-acceptance/bin/ziti-<immutable-id>`
-(concrete tag or commit SHA) so repeated local runs are instant and CI can cache the
-directory.
+Cache resolved binaries under e.g.
+`~/.cache/ziti-acceptance/bin/ziti-<immutable-id>-<goos>-<goarch>` (concrete tag or
+commit SHA, plus the platform the binary was produced for) so repeated local runs are
+instant and CI can cache the directory.
 
 ### Layer 2: bootstrap
 
@@ -526,12 +527,14 @@ source:
   (`/releases/tags/<tag>`) rather than constructing it.
 - **acquire/build.go**: `git` fetch of the ref + `go build` of the `ziti` binary for
   any non-release ref (branch/tag/SHA). Needs the Go toolchain (present in CI and
-  locally).
+  locally). Cross-builds when the requested platform is not the one the build runs on,
+  which also disables cgo so no C toolchain for the target is needed.
 - **acquire/cache.go**: cache keyed by the *immutable* resolved id (concrete tag or
-  commit SHA, never a mutable selector) under `~/.cache/ziti-acceptance/bin/ziti-<id>`;
-  CI caches the dir. Selectors are resolved to that id before lookup. If CI ever runs
-  multiple platforms, include `runner.os`/`GOOS`/`GOARCH` in the CI cache key so a
-  binary built for one platform isn't reused on another.
+  commit SHA, never a mutable selector) and the target platform, under
+  `~/.cache/ziti-acceptance/bin/ziti-<id>-<goos>-<goarch>`; CI caches the dir. Selectors
+  are resolved to that id before lookup. The platform is part of the entry name, so a
+  binary produced for one platform is never reused on another, and a CI cache shared
+  across runners is safe without adding `runner.os` to the CI cache key.
 - **ziticli/ziticli.go**: exec wrapper that runs the acquired binary with a
   per-harness env (isolated CLI login/config dir so parallel harnesses and the dev's
   own ziti CLI don't collide) and the `ZITI_*` vars the config generators read.

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -71,9 +71,16 @@ latest       PASS  (1m03s)
 ## Binary cache
 
 Downloaded (and, later, source-built) ziti binaries land in
-`<user cache dir>/ziti-acceptance/bin/ziti-<version>`, keyed by the concrete
-resolved version. Override the location with `ZITI_ACCEPTANCE_CACHE`. Deleting the
-directory is always safe; the next run re-downloads.
+`<user cache dir>/ziti-acceptance/bin/ziti-<version>-<goos>-<goarch>`, keyed by the
+concrete resolved version and the platform the binary was produced for. Override the
+location with `ZITI_ACCEPTANCE_CACHE`. Deleting the directory is always safe; the next
+run re-downloads.
+
+Binaries target the platform the harness runs on unless a caller passes
+`acquire.WithPlatform`, which release selectors honor when picking an asset and git-ref
+selectors honor by cross-building. Since the platform is part of the entry name, one
+version can be cached for several platforms at once and a binary is never handed to a
+platform that cannot run it.
 
 `GITHUB_TOKEN`, if set, is used for GitHub API calls. Without it, GitHub's
 unauthenticated limit (60 requests/hour per IP) can bite after a few matrix runs;

--- a/acquire/acquire.go
+++ b/acquire/acquire.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -31,15 +32,49 @@ type Option func(*buildOptions)
 // buildOptions holds the resolved acquire options.
 type buildOptions struct {
 	stampVersion string
+	goos         string
+	goarch       string
 }
 
-// newBuildOptions applies opts and returns the resolved options.
+// newBuildOptions applies opts and returns the resolved options, defaulting the
+// target platform to the one this process runs on.
 func newBuildOptions(opts []Option) buildOptions {
-	var bo buildOptions
+	bo := buildOptions{
+		goos:   runtime.GOOS,
+		goarch: runtime.GOARCH,
+	}
 	for _, opt := range opts {
 		opt(&bo)
 	}
 	return bo
+}
+
+// platform is the target platform as it appears in cache entry names.
+func (bo buildOptions) platform() string {
+	return platformName(bo.goos, bo.goarch)
+}
+
+// validate rejects a target platform that cannot describe a real binary. It is a
+// structural check, not a list of known platforms: an empty value matches every
+// release asset, since asset selection is a substring match, and would otherwise
+// download an arbitrary one and cache it under a nameless platform. A value
+// carrying a path separator would escape the cache directory.
+func (bo buildOptions) validate() error {
+	if err := validPlatformPart("GOOS", bo.goos); err != nil {
+		return err
+	}
+	return validPlatformPart("GOARCH", bo.goarch)
+}
+
+// validPlatformPart checks one half of a target platform.
+func validPlatformPart(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", name)
+	}
+	if value == "." || value == ".." || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("%s %q must not name a path", name, value)
+	}
+	return nil
 }
 
 // WithVersion stamps the built binary's common/version Version (and Revision) when a git-ref
@@ -50,14 +85,30 @@ func WithVersion(version string) Option {
 	return func(o *buildOptions) { o.stampVersion = version }
 }
 
+// WithPlatform targets goos/goarch instead of the platform this process runs on.
+// Release selectors then download that platform's asset, and git-ref selectors
+// cross-build for it. Use it when the binary runs somewhere other than the
+// machine acquiring it, for example a test harness on a mac provisioning
+// linux/amd64 hosts. Cache entries record the platform they were produced for, so
+// the same commit acquired for two platforms caches separately.
+func WithPlatform(goos, goarch string) Option {
+	return func(o *buildOptions) {
+		o.goos = goos
+		o.goarch = goarch
+	}
+}
+
 // Ziti resolves selector to an immutable id and returns the path to a ziti
 // binary for it: release selectors download the release artifact on a cache
 // miss, and git-ref selectors (a branch, non-release tag, or SHA) resolve to a
 // commit and build from source. The cache is keyed on the immutable id (tag or
-// SHA), so a moved mutable selector misses the cache rather than serving a
-// stale binary.
+// SHA) and the target platform, so a moved mutable selector misses the cache
+// rather than serving a stale binary, and a binary is never served to a platform
+// it was not produced for.
+//
+// The binary targets this process's platform unless WithPlatform selects another.
 func Ziti(ctx context.Context, selector string, cfg Versions, src ReleaseSource, cacheDir string, opts ...Option) (string, ResolvedID, error) {
-	return acquireFor(ctx, selector, cfg, src, cacheDir, runtime.GOOS, runtime.GOARCH, opts...)
+	return acquireFor(ctx, selector, cfg, src, cacheDir, opts...)
 }
 
 // acquireMemo caches successful Ziti results per selector for the life of the
@@ -90,11 +141,12 @@ func ZitiMemoized(ctx context.Context, selector string, cfg Versions, src Releas
 	acquireMemo.Lock()
 	defer acquireMemo.Unlock()
 
-	// A stamped version produces a distinct binary, so it must key the memo separately from an
-	// unstamped acquire of the same selector.
-	memoKey := selector
-	if v := newBuildOptions(opts).stampVersion; v != "" {
-		memoKey = selector + "\x00" + v
+	// A stamped version and a target platform each produce a distinct binary, so both must key the
+	// memo separately from a plain acquire of the same selector.
+	bo := newBuildOptions(opts)
+	memoKey := selector + "\x00" + bo.platform()
+	if bo.stampVersion != "" {
+		memoKey += "\x00" + bo.stampVersion
 	}
 
 	if entry, ok := acquireMemo.bySelector[memoKey]; ok {
@@ -108,9 +160,16 @@ func ZitiMemoized(ctx context.Context, selector string, cfg Versions, src Releas
 	return binPath, id, nil
 }
 
-// acquireFor is Ziti with the platform injected, so tests can pin it.
-func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseSource, cacheDir, goos, goarch string, opts ...Option) (string, ResolvedID, error) {
+// acquireFor is Ziti with the options already resolved, including the target
+// platform, which defaults to this process's but may be pinned via WithPlatform.
+func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseSource, cacheDir string, opts ...Option) (string, ResolvedID, error) {
 	bo := newBuildOptions(opts)
+	// Validate before any cache lookup or asset selection, both of which would otherwise accept a
+	// meaningless platform and produce a binary that cannot be attributed to one.
+	if err := bo.validate(); err != nil {
+		return "", ResolvedID{}, err
+	}
+
 	spec, err := ParseSpec(selector, cfg)
 	if err != nil {
 		return "", ResolvedID{}, err
@@ -151,12 +210,12 @@ func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseS
 		}
 
 		if useCache {
-			binPath := cachedBinaryPath(cacheDir, cacheKey)
+			binPath := cachedBinaryPath(cacheDir, cacheKey, bo.platform())
 			if _, statErr := os.Stat(binPath); statErr == nil {
 				return binPath, id, nil
 			}
 		}
-		path, err := buildZitiFromSource(ctx, cfg.Source, sha, cacheDir, cacheKey, sdkReplace, bo.stampVersion)
+		path, err := buildZitiFromSource(ctx, cfg.Source, sha, cacheDir, cacheKey, sdkReplace, bo.stampVersion, bo.goos, bo.goarch)
 		if err != nil {
 			return "", ResolvedID{}, err
 		}
@@ -167,7 +226,7 @@ func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseS
 	// binary is already cached: the cache entry is proof the release exists.
 	// Moving selectors (latest, wildcards) must still resolve.
 	if tag, pinned := pinnedTag(spec, cfg); pinned {
-		binPath := cachedBinaryPath(cacheDir, tag)
+		binPath := cachedBinaryPath(cacheDir, tag, bo.platform())
 		if _, statErr := os.Stat(binPath); statErr == nil {
 			return binPath, ResolvedID{Tag: tag}, nil
 		}
@@ -178,7 +237,7 @@ func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseS
 		return "", ResolvedID{}, err
 	}
 
-	binPath := cachedBinaryPath(cacheDir, id.Tag)
+	binPath := cachedBinaryPath(cacheDir, id.Tag, bo.platform())
 	if _, statErr := os.Stat(binPath); statErr == nil {
 		return binPath, id, nil
 	}
@@ -187,12 +246,12 @@ func acquireFor(ctx context.Context, selector string, cfg Versions, src ReleaseS
 	if err != nil {
 		return "", ResolvedID{}, err
 	}
-	asset, err := selectAsset(detail.Assets, goos, goarch)
+	asset, err := selectAsset(detail.Assets, bo.goos, bo.goarch)
 	if err != nil {
 		return "", ResolvedID{}, fmt.Errorf("release %s: %w", id.Tag, err)
 	}
 
-	path, err := downloadAndInstall(ctx, src, asset, cacheDir, id.Tag)
+	path, err := downloadAndInstall(ctx, src, asset, cacheDir, id.Tag, bo.platform())
 	if err != nil {
 		return "", ResolvedID{}, err
 	}
@@ -223,7 +282,7 @@ func pinnedTag(spec Spec, cfg Versions) (string, bool) {
 // downloadAndInstall downloads asset, extracts the ziti binary, and installs it
 // into the cache. All temp files live in the cache dir so the final rename is
 // same-filesystem and atomic.
-func downloadAndInstall(ctx context.Context, src ReleaseSource, asset Asset, cacheDir, id string) (string, error) {
+func downloadAndInstall(ctx context.Context, src ReleaseSource, asset Asset, cacheDir, id, platform string) (string, error) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("creating cache dir: %w", err)
 	}
@@ -255,13 +314,42 @@ func downloadAndInstall(ctx context.Context, src ReleaseSource, asset Asset, cac
 	if err := extractZitiBinary(archive, extractedName); err != nil {
 		return "", fmt.Errorf("extracting %s: %w", asset.Name, err)
 	}
-	return installIntoCache(cacheDir, id, extractedName)
+	return installIntoCache(cacheDir, id, platform, extractedName)
 }
 
 // archAliases maps a GOARCH to the names release assets use for it.
 var archAliases = map[string][]string{
 	"amd64": {"amd64", "x86_64"},
 	"arm64": {"arm64", "aarch64"},
+}
+
+// assetNameTokens splits an asset name into the tokens platform matching compares
+// against: runs of letters, digits and underscores, so "ziti-linux-x86_64-2.0.8.tar.gz"
+// yields "linux" and "x86_64" among others. The underscore stays inside a token
+// because arch names such as x86_64 contain one.
+func assetNameTokens(name string) []string {
+	return strings.FieldsFunc(name, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '_'
+	})
+}
+
+// matchesPlatform reports whether tokens name goos immediately followed by one of
+// arches, as the "<goos>-<arch>" segment of a release asset name does.
+//
+// Both halves must be whole tokens, and they must be adjacent in that order. Whole
+// tokens stop a partial name passing for a real one, where "lin"/"md64" would select
+// the linux/amd64 asset. Adjacency ties the two halves to the same segment: tested
+// independently, an arch could match an unrelated token elsewhere in the name, so
+// "linux"/"64" would match ziti-linux-amd64-2.0.64.tar.gz through its version. Either
+// way the binary would be cached under a platform nothing was built for, instead of
+// reaching the "no asset found" error an unknown platform should get.
+func matchesPlatform(tokens []string, goos string, arches []string) bool {
+	for i := 0; i+1 < len(tokens); i++ {
+		if tokens[i] == goos && slices.Contains(arches, tokens[i+1]) {
+			return true
+		}
+	}
+	return false
 }
 
 // selectAsset picks the release asset for goos/goarch. Only tar.gz archives are
@@ -276,17 +364,7 @@ func selectAsset(assets []Asset, goos, goarch string) (Asset, error) {
 	var zipMatch string
 	for _, a := range assets {
 		name := strings.ToLower(a.Name)
-		if !strings.Contains(name, goos) {
-			continue
-		}
-		archMatch := false
-		for _, arch := range arches {
-			if strings.Contains(name, arch) {
-				archMatch = true
-				break
-			}
-		}
-		if !archMatch {
+		if !matchesPlatform(assetNameTokens(name), goos, arches) {
 			continue
 		}
 		if strings.HasSuffix(name, ".tar.gz") {

--- a/acquire/acquire_test.go
+++ b/acquire/acquire_test.go
@@ -34,6 +34,19 @@ import (
 
 const fakeBinaryContent = "#!/bin/sh\necho fake ziti\n"
 
+const (
+	testGoos   = "linux"
+	testGoarch = "amd64"
+	// testPlatformName is how testGoos/testGoarch appear in cache entry names.
+	testPlatformName = testGoos + "-" + testGoarch
+)
+
+// testPlatform pins acquisition to a fixed platform, so tests assert the same cache paths and select
+// the same release assets whatever machine they run on.
+func testPlatform() []Option {
+	return []Option{WithPlatform(testGoos, testGoarch)}
+}
+
 // makeTarGz builds a tar.gz containing the named entries.
 func makeTarGz(t *testing.T, entries map[string]string) []byte {
 	t.Helper()
@@ -102,10 +115,10 @@ func TestAcquireDownloadsExtractsAndCaches(t *testing.T) {
 	cfg := testCfg()
 
 	// latest -> v2.0.8 -> download, extract, install
-	path, id, err := acquireFor(ctx, "latest", cfg, rs.source(), cacheDir, "linux", "amd64")
+	path, id, err := acquireFor(ctx, "latest", cfg, rs.source(), cacheDir, testPlatform()...)
 	require.NoError(t, err)
 	require.Equal(t, "v2.0.8", id.Tag)
-	require.Equal(t, cachedBinaryPath(cacheDir, "v2.0.8"), path)
+	require.Equal(t, cachedBinaryPath(cacheDir, "v2.0.8", testPlatformName), path)
 
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -122,7 +135,7 @@ func TestAcquireDownloadsExtractsAndCaches(t *testing.T) {
 	require.Len(t, entries, 1)
 
 	// second acquire hits the cache: same path, no new download
-	path2, _, err := acquireFor(ctx, "latest", cfg, rs.source(), cacheDir, "linux", "amd64")
+	path2, _, err := acquireFor(ctx, "latest", cfg, rs.source(), cacheDir, testPlatform()...)
 	require.NoError(t, err)
 	require.Equal(t, path, path2)
 	require.Equal(t, int32(1), rs.downloads.Load(), "cache hit must not re-download")
@@ -135,13 +148,13 @@ func TestAcquireGitRefShaCached(t *testing.T) {
 	req := require.New(t)
 	cacheDir := t.TempDir()
 	sha := "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334"
-	req.NoError(os.WriteFile(cachedBinaryPath(cacheDir, sha), []byte(fakeBinaryContent), 0o755))
+	req.NoError(os.WriteFile(cachedBinaryPath(cacheDir, sha, testPlatformName), []byte(fakeBinaryContent), 0o755))
 
-	path, id, err := acquireFor(context.Background(), sha, testCfg(), erroringSource{}, cacheDir, "linux", "amd64")
+	path, id, err := acquireFor(context.Background(), sha, testCfg(), erroringSource{}, cacheDir, testPlatform()...)
 	req.NoError(err)
 	req.True(id.SourceBuilt)
 	req.Equal(sha, id.Tag)
-	req.Equal(cachedBinaryPath(cacheDir, sha), path)
+	req.Equal(cachedBinaryPath(cacheDir, sha, testPlatformName), path)
 }
 
 // erroringSource fails every API operation, proving a code path makes no API
@@ -170,29 +183,29 @@ func TestAcquirePinnedCachedSkipsAPI(t *testing.T) {
 
 	// pre-place cached binaries for the pinned tags
 	for _, tag := range []string{"v1.6.17", "v2.0.7"} {
-		req.NoError(os.WriteFile(cachedBinaryPath(cacheDir, tag), []byte(fakeBinaryContent), 0o755))
+		req.NoError(os.WriteFile(cachedBinaryPath(cacheDir, tag, testPlatformName), []byte(fakeBinaryContent), 0o755))
 	}
 
 	// explicit version: cache hit, no API
-	path, id, err := acquireFor(ctx, "v2.0.7", cfg, erroringSource{}, cacheDir, "linux", "amd64")
+	path, id, err := acquireFor(ctx, "v2.0.7", cfg, erroringSource{}, cacheDir, testPlatform()...)
 	req.NoError(err)
 	req.Equal("v2.0.7", id.Tag)
-	req.Equal(cachedBinaryPath(cacheDir, "v2.0.7"), path)
+	req.Equal(cachedBinaryPath(cacheDir, "v2.0.7", testPlatformName), path)
 
 	// pinned label (maint-lts -> v1.6.17): cache hit, no API
-	path, id, err = acquireFor(ctx, "maint-lts", cfg, erroringSource{}, cacheDir, "linux", "amd64")
+	path, id, err = acquireFor(ctx, "maint-lts", cfg, erroringSource{}, cacheDir, testPlatform()...)
 	req.NoError(err)
 	req.Equal("v1.6.17", id.Tag)
-	req.Equal(cachedBinaryPath(cacheDir, "v1.6.17"), path)
+	req.Equal(cachedBinaryPath(cacheDir, "v1.6.17", testPlatformName), path)
 
 	// moving selectors must still resolve, even with a full cache
-	_, _, err = acquireFor(ctx, "latest", cfg, erroringSource{}, cacheDir, "linux", "amd64")
+	_, _, err = acquireFor(ctx, "latest", cfg, erroringSource{}, cacheDir, testPlatform()...)
 	req.ErrorContains(err, "unexpected API call")
-	_, _, err = acquireFor(ctx, "active-lts", cfg, erroringSource{}, cacheDir, "linux", "amd64") // v2.0.x wildcard
+	_, _, err = acquireFor(ctx, "active-lts", cfg, erroringSource{}, cacheDir, testPlatform()...) // v2.0.x wildcard
 	req.ErrorContains(err, "unexpected API call")
 
 	// a pinned tag with a cold cache must verify via the API
-	_, _, err = acquireFor(ctx, "v9.9.9", cfg, erroringSource{}, cacheDir, "linux", "amd64")
+	_, _, err = acquireFor(ctx, "v9.9.9", cfg, erroringSource{}, cacheDir, testPlatform()...)
 	req.ErrorContains(err, "unexpected API call")
 }
 

--- a/acquire/build.go
+++ b/acquire/build.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -132,9 +133,10 @@ func resolveRefToSha(ctx context.Context, src Source, ref string) (string, error
 // co-development mode (sdkReplace non-empty) the ref's pinned sdk-golang is
 // replaced with that local tree before building. When stampVersion is non-empty the
 // binary's common/version Version and Revision are stamped via -ldflags, so it
-// reports that version instead of the unstamped dev default. The source checkout is
-// temporary; Go's module cache keeps rebuilds reasonably fast.
-func buildZitiFromSource(ctx context.Context, src Source, sha, cacheDir, cacheKey, sdkReplace, stampVersion string) (string, error) {
+// reports that version instead of the unstamped dev default. The build targets
+// goos/goarch, cross-compiling when they differ from this process's platform. The
+// source checkout is temporary; Go's module cache keeps rebuilds reasonably fast.
+func buildZitiFromSource(ctx context.Context, src Source, sha, cacheDir, cacheKey, sdkReplace, stampVersion, goos, goarch string) (string, error) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("creating cache dir: %w", err)
 	}
@@ -156,17 +158,26 @@ func buildZitiFromSource(ctx context.Context, src Source, sha, cacheDir, cacheKe
 		}
 	}
 
+	goEnv := goBuildEnv(goos, goarch)
+
 	if sdkReplace != "" {
-		if _, err := runCmd(ctx, srcDir, "go", "mod", "edit",
+		if _, err := runCmdEnv(ctx, srcDir, goEnv, "go", "mod", "edit",
 			"-replace", "github.com/openziti/sdk-golang/v2="+sdkReplace); err != nil {
 			return "", fmt.Errorf("replacing sdk-golang with local tree: %w", err)
 		}
-		if _, err := runCmd(ctx, srcDir, "go", "mod", "tidy"); err != nil {
+		if _, err := runCmdEnv(ctx, srcDir, goEnv, "go", "mod", "tidy"); err != nil {
 			return "", fmt.Errorf("tidying after sdk replace: %w", err)
 		}
 	}
 
-	builtPath := filepath.Join(cacheDir, "build-"+sha[:12]+".tmp")
+	// The output file is unique per build: the same commit can be built concurrently for different
+	// platforms or stamped versions, and a shared temp name would have them overwrite each other.
+	built, err := os.CreateTemp(cacheDir, "build-"+sha[:12]+"-*")
+	if err != nil {
+		return "", fmt.Errorf("creating build temp file: %w", err)
+	}
+	builtPath := built.Name()
+	_ = built.Close()
 	defer func() { _ = os.Remove(builtPath) }()
 
 	buildArgs := []string{"build"}
@@ -179,7 +190,7 @@ func buildZitiFromSource(ctx context.Context, src Source, sha, cacheDir, cacheKe
 	}
 	buildArgs = append(buildArgs, "-o", builtPath, "./ziti")
 
-	if _, err := runCmd(ctx, srcDir, "go", buildArgs...); err != nil {
+	if _, err := runCmdEnv(ctx, srcDir, goEnv, "go", buildArgs...); err != nil {
 		err = fmt.Errorf("building ziti at %s: %w", sha[:12], err)
 		if sdkReplace == "" {
 			err = fmt.Errorf("%w\n(if this ref co-develops with the SDK, set %s=true to build it against the local SDK tree)",
@@ -188,7 +199,7 @@ func buildZitiFromSource(ctx context.Context, src Source, sha, cacheDir, cacheKe
 		return "", err
 	}
 
-	return installIntoCache(cacheDir, cacheKey, builtPath)
+	return installIntoCache(cacheDir, cacheKey, platformName(goos, goarch), builtPath)
 }
 
 // gitURL is the https clone URL for the source repository.
@@ -196,10 +207,35 @@ func gitURL(src Source) string {
 	return fmt.Sprintf("https://github.com/%s/%s.git", src.Org, src.Repo)
 }
 
-// runCmd runs a command, returning stdout and folding stderr into the error.
+// goBuildEnv is the environment for the go commands that produce the binary, targeting goos/goarch.
+//
+// The target is always set explicitly, including when it matches the platform this process runs on.
+// Leaving it to the ambient environment would let an exported GOOS or GOARCH decide what gets built
+// while the result is cached under the name of the platform that was asked for, which is exactly the
+// mismatch the platform-keyed cache exists to prevent.
+//
+// Only cgo is left to the ambient environment for a native build. A cross-build disables it, since it
+// would otherwise want a C toolchain for the target; ziti is pure Go, so nothing is lost.
+func goBuildEnv(goos, goarch string) []string {
+	env := append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+	if goos != runtime.GOOS || goarch != runtime.GOARCH {
+		env = append(env, "CGO_ENABLED=0")
+	}
+	return env
+}
+
+// runCmd runs a command with the ambient environment, returning stdout and folding stderr into the
+// error.
 func runCmd(ctx context.Context, dir, name string, args ...string) (string, error) {
+	return runCmdEnv(ctx, dir, nil, name, args...)
+}
+
+// runCmdEnv is runCmd with an explicit environment; a nil env inherits this process's. Only the go
+// commands take an env: the git steps must not be told to target another platform.
+func runCmdEnv(ctx context.Context, dir string, env []string, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	cmd.Env = env
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/acquire/cache.go
+++ b/acquire/cache.go
@@ -38,22 +38,29 @@ func DefaultCacheDir() (string, error) {
 	return filepath.Join(base, "ziti-acceptance", "bin"), nil
 }
 
+// platformName renders a target platform the way cache entries name it.
+func platformName(goos, goarch string) string {
+	return goos + "-" + goarch
+}
+
 // cachedBinaryPath is the cache location for the binary of an immutable id (a
-// concrete release tag or a commit SHA). The cache is keyed only on immutable ids,
-// never on a mutable selector, so a moved selector misses rather than serving a
-// stale binary.
-func cachedBinaryPath(cacheDir, id string) string {
-	return filepath.Join(cacheDir, "ziti-"+id)
+// concrete release tag or a commit SHA) built for platform ("<goos>-<goarch>").
+// The cache is keyed only on immutable ids, never on a mutable selector, so a
+// moved selector misses rather than serving a stale binary. Every entry names the
+// platform it was produced for, so a binary is never served to a platform it
+// cannot run on.
+func cachedBinaryPath(cacheDir, id, platform string) string {
+	return filepath.Join(cacheDir, "ziti-"+id+"-"+platform)
 }
 
 // installIntoCache atomically installs the file at srcPath as the cached binary for
-// id: a rename within the cache directory, so a concurrent or interrupted run never
-// observes a partial binary.
-func installIntoCache(cacheDir, id, srcPath string) (string, error) {
+// id on platform: a rename within the cache directory, so a concurrent or
+// interrupted run never observes a partial binary.
+func installIntoCache(cacheDir, id, platform, srcPath string) (string, error) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("creating cache dir: %w", err)
 	}
-	dst := cachedBinaryPath(cacheDir, id)
+	dst := cachedBinaryPath(cacheDir, id, platform)
 	if err := os.Rename(srcPath, dst); err != nil {
 		return "", fmt.Errorf("installing into cache: %w", err)
 	}

--- a/acquire/platform_test.go
+++ b/acquire/platform_test.go
@@ -1,0 +1,243 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package acquire
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCachedBinaryPathIncludesPlatform pins that cache entries name the platform
+// they were produced for, so one id can be cached for several platforms at once.
+func TestCachedBinaryPathIncludesPlatform(t *testing.T) {
+	req := require.New(t)
+
+	linux := cachedBinaryPath("/cache", "v2.0.8", platformName("linux", "amd64"))
+	darwin := cachedBinaryPath("/cache", "v2.0.8", platformName("darwin", "arm64"))
+
+	req.NotEqual(linux, darwin)
+	req.Contains(linux, "ziti-v2.0.8-linux-amd64")
+	req.Contains(darwin, "ziti-v2.0.8-darwin-arm64")
+}
+
+// TestAcquireCacheIsPerPlatform pins the reason the platform belongs in the cache
+// key: a binary cached for one platform must never satisfy a request for another,
+// which before would have handed a caller a binary it cannot execute. The cache
+// hit takes no API call, so the erroring source proves the miss.
+func TestAcquireCacheIsPerPlatform(t *testing.T) {
+	req := require.New(t)
+	cacheDir := t.TempDir()
+	ctx := context.Background()
+	cfg := testCfg()
+
+	req.NoError(os.WriteFile(cachedBinaryPath(cacheDir, "v2.0.7", platformName("linux", "amd64")),
+		[]byte(fakeBinaryContent), 0o755))
+
+	// the platform it was cached for: hit, no API call
+	path, _, err := acquireFor(ctx, "v2.0.7", cfg, erroringSource{}, cacheDir, WithPlatform("linux", "amd64"))
+	req.NoError(err)
+	req.Equal(cachedBinaryPath(cacheDir, "v2.0.7", platformName("linux", "amd64")), path)
+
+	// any other platform: miss, so it goes to the API rather than serving the linux binary
+	_, _, err = acquireFor(ctx, "v2.0.7", cfg, erroringSource{}, cacheDir, WithPlatform("darwin", "arm64"))
+	req.ErrorContains(err, "unexpected API call")
+}
+
+// TestAcquireSelectsAssetForRequestedPlatform pins that WithPlatform reaches asset
+// selection, so a release is downloaded for the platform asked for rather than the
+// one doing the asking.
+func TestAcquireSelectsAssetForRequestedPlatform(t *testing.T) {
+	req := require.New(t)
+	rs := newReleaseServer(t)
+	ctx := context.Background()
+	cfg := testCfg()
+
+	// the fixture publishes a linux/amd64 asset
+	path, id, err := acquireFor(ctx, "v2.0.8", cfg, rs.source(), t.TempDir(), WithPlatform("linux", "amd64"))
+	req.NoError(err)
+	req.Equal("v2.0.8", id.Tag)
+	content, err := os.ReadFile(path)
+	req.NoError(err)
+	req.Equal(fakeBinaryContent, string(content))
+
+	// and none for darwin/arm64, so asking for that platform must fail rather than
+	// quietly fetching the linux one
+	_, _, err = acquireFor(ctx, "v2.0.8", cfg, rs.source(), t.TempDir(), WithPlatform("darwin", "arm64"))
+	req.ErrorContains(err, "no asset found")
+	req.ErrorContains(err, "darwin")
+}
+
+// TestZitiMemoizedIsPerPlatform pins that the in-process memo distinguishes
+// platforms, so a memoized result is not replayed for a platform it was not
+// acquired for.
+func TestZitiMemoizedIsPerPlatform(t *testing.T) {
+	req := require.New(t)
+	t.Cleanup(resetAcquireMemo)
+	resetAcquireMemo()
+
+	rs := newReleaseServer(t)
+	cacheDir := t.TempDir()
+	ctx := context.Background()
+	cfg := testCfg()
+
+	_, id, err := ZitiMemoized(ctx, "latest", cfg, rs.source(), cacheDir, WithPlatform("linux", "amd64"))
+	req.NoError(err)
+	req.Equal("v2.0.8", id.Tag)
+
+	// same selector, different platform: no memo hit, so it resolves again
+	_, _, err = ZitiMemoized(ctx, "latest", cfg, erroringSource{}, cacheDir, WithPlatform("darwin", "arm64"))
+	req.ErrorContains(err, "unexpected API call")
+}
+
+// TestGoBuildEnv pins what the go commands are told. The target is always explicit,
+// including for a native build: leaving it ambient would let an exported GOOS decide
+// what gets built while the result is cached under the platform that was asked for.
+// Only cgo differs, staying ambient natively and off when cross-building.
+func TestGoBuildEnv(t *testing.T) {
+	req := require.New(t)
+
+	native := goBuildEnv(runtime.GOOS, runtime.GOARCH)
+	req.True(slices.Contains(native, "GOOS="+runtime.GOOS), "native build must still pin GOOS")
+	req.True(slices.Contains(native, "GOARCH="+runtime.GOARCH), "native build must still pin GOARCH")
+	req.False(slices.Contains(native, "CGO_ENABLED=0"), "native build must leave cgo alone")
+
+	crossGoarch := "arm64"
+	if runtime.GOARCH == crossGoarch {
+		crossGoarch = "amd64"
+	}
+	cross := goBuildEnv("linux", crossGoarch)
+	req.True(slices.Contains(cross, "GOOS=linux"))
+	req.True(slices.Contains(cross, "GOARCH="+crossGoarch))
+	req.True(slices.Contains(cross, "CGO_ENABLED=0"))
+}
+
+// TestGoBuildEnvOverridesAmbientTarget pins that an exported GOOS/GOARCH cannot
+// steer the build away from the platform that was asked for. The target is appended
+// last, and the last assignment of a variable is the one the child process sees.
+func TestGoBuildEnvOverridesAmbientTarget(t *testing.T) {
+	req := require.New(t)
+
+	t.Setenv("GOOS", "windows")
+	t.Setenv("GOARCH", "386")
+
+	env := goBuildEnv("linux", "amd64")
+
+	req.Equal("GOOS=linux", lastAssignment(env, "GOOS"))
+	req.Equal("GOARCH=amd64", lastAssignment(env, "GOARCH"))
+}
+
+// lastAssignment returns the final entry setting name, which is the one that wins.
+func lastAssignment(env []string, name string) string {
+	found := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, name+"=") {
+			found = kv
+		}
+	}
+	return found
+}
+
+// TestSelectAssetMatchesWholeTokens pins that a platform name must match a whole
+// token of the asset name. Under a substring test a partial name passed for a real
+// one, so "lin"/"md64" selected the linux/amd64 asset and it was cached under a
+// platform nothing was built for. Structural validation cannot catch this: those are
+// perfectly well-formed values, they are just not platforms.
+func TestSelectAssetMatchesWholeTokens(t *testing.T) {
+	assets := []Asset{
+		{Name: "ziti-windows-amd64-2.0.8.zip"},
+		{Name: "ziti-linux-x86_64-2.0.8.tar.gz"},
+		{Name: "ziti-darwin-arm64-2.0.8.tar.gz"},
+	}
+
+	for _, tc := range []struct{ name, goos, goarch string }{
+		{"truncated goos", "lin", "amd64"},
+		{"truncated goarch", "linux", "md64"},
+		{"both truncated", "lin", "md64"},
+		{"goarch digits only", "linux", "64"},
+		{"goos superstring", "linuxx", "amd64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := selectAsset(assets, tc.goos, tc.goarch)
+			require.ErrorContains(t, err, "no asset found")
+		})
+	}
+
+	// the real platform still resolves, including via an arch alias spelled with an
+	// underscore, which must stay one token rather than splitting into x86 and 64
+	a, err := selectAsset(assets, "linux", "amd64")
+	require.NoError(t, err)
+	require.Equal(t, "ziti-linux-x86_64-2.0.8.tar.gz", a.Name)
+}
+
+// TestSelectAssetRequiresAdjacentPlatformTokens pins that the os and arch must sit
+// together in that order, as they do in the "<goos>-<arch>" segment of an asset name.
+// Checked independently, an arch matches any token anywhere, so a version ending in
+// the arch name is enough for a bogus platform to select a real asset.
+func TestSelectAssetRequiresAdjacentPlatformTokens(t *testing.T) {
+	// a version whose last component collides with an architecture name
+	assets := []Asset{{Name: "ziti-linux-amd64-2.0.64.tar.gz"}}
+
+	_, err := selectAsset(assets, "linux", "64")
+	require.ErrorContains(t, err, "no asset found",
+		"the version's trailing 64 must not stand in for the architecture")
+
+	// reversed order is not a match either
+	_, err = selectAsset([]Asset{{Name: "ziti-amd64-linux-2.0.8.tar.gz"}}, "linux", "amd64")
+	require.ErrorContains(t, err, "no asset found")
+
+	// the genuine pairing in the same name still resolves
+	a, err := selectAsset(assets, "linux", "amd64")
+	require.NoError(t, err)
+	require.Equal(t, "ziti-linux-amd64-2.0.64.tar.gz", a.Name)
+}
+
+// TestAcquireRejectsUnusablePlatform pins that a platform that cannot describe a
+// real binary is refused up front. Asset selection is a substring match, so an empty
+// value matches every asset and would otherwise download an arbitrary one and cache
+// it under a nameless platform. A path-bearing value would escape the cache dir.
+func TestAcquireRejectsUnusablePlatform(t *testing.T) {
+	req := require.New(t)
+	rs := newReleaseServer(t)
+	ctx := context.Background()
+	cfg := testCfg()
+
+	for _, tc := range []struct {
+		name, goos, goarch, wants string
+	}{
+		{"empty goos", "", "amd64", "GOOS must not be empty"},
+		{"empty goarch", "linux", "", "GOARCH must not be empty"},
+		{"both empty", "", "", "GOOS must not be empty"},
+		{"goos traversal", "../..", "amd64", "must not name a path"},
+		{"goarch traversal", "linux", "..", "must not name a path"},
+		{"goarch separator", "linux", "amd64/x", "must not name a path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := acquireFor(ctx, "v2.0.8", cfg, rs.source(), t.TempDir(),
+				WithPlatform(tc.goos, tc.goarch))
+			require.ErrorContains(t, err, tc.wants)
+		})
+	}
+
+	// nothing was downloaded or cached on the way to those errors
+	req.Zero(rs.downloads.Load())
+}


### PR DESCRIPTION
Adds `acquire.WithPlatform(goos, goarch)`, so a caller can acquire a ziti binary for a platform other than the one it is running on. Release selectors download that platform's asset and git-ref selectors cross-build for it.

This is needed by the ziti fablab upgrade test, which builds a ziti binary from a git ref and stages it onto linux/amd64 AWS hosts. Driven from a mac or an arm box it previously produced a binary those hosts cannot execute.

Two existing latent problems fall out of the same area and are fixed here:

- The binary cache was keyed on the resolved id alone, with no record of the platform a binary was produced for. It now includes the platform, so entries cannot be crossed between platforms. Existing cache entries miss once and are re-acquired.
- Asset selection matched the platform name as a substring anywhere in the asset filename. It now matches whole, adjacent `<goos>-<arch>` tokens, so a partial or bogus platform gets the "no asset found" error rather than an arbitrary asset.

Existing callers are unaffected: the target defaults to the platform the process runs on.