### PR TITLE
Refuse dials for unknown edge conn ids

### DIFF
--- a/ziti/edge/dial_no_sink_test.go
+++ b/ziti/edge/dial_no_sink_test.go
@@ -1,0 +1,98 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// replyCapturingChannel records what the SDK sends back to the router.
+type replyCapturingChannel struct {
+	channel.Channel
+	sent chan *channel.Message
+}
+
+func (ch *replyCapturingChannel) Send(s channel.Sendable) error {
+	// Sendable is an envelope wrapper once a timeout is attached, so take the message
+	// off it rather than type-asserting to *channel.Message.
+	select {
+	case ch.sent <- s.Msg():
+	default:
+	}
+	return nil
+}
+
+func (ch *replyCapturingChannel) TrySend(s channel.Sendable) (bool, error) {
+	return true, ch.Send(s)
+}
+
+func (ch *replyCapturingChannel) IsClosed() bool { return false }
+func (ch *replyCapturingChannel) Label() string  { return "test" }
+
+// GetSenders returns nil so the SdkChannel type assertion callers make fails and they
+// fall back to sending directly on this channel, where Send records the message.
+func (ch *replyCapturingChannel) GetSenders() channel.Senders { return nil }
+
+// Test_DialForUnknownConnIsAnswered pins the contract the router depends on: a dial
+// for a conn the SDK no longer hosts must be answered, not dropped.
+//
+// A hosted listener can close while its terminator is still selectable at the
+// controller, so the router will forward dials for it. The router waits for a reply
+// with a route timeout longer than the dialing client's connect timeout, so silence
+// here surfaces to the client as a connect timeout rather than a fast, retriable
+// failure.
+func Test_DialForUnknownConnIsAnswered(t *testing.T) {
+	req := require.New(t)
+
+	mux := NewChannelConnMapMux[any](nil)
+	ch := &replyCapturingChannel{sent: make(chan *channel.Message, 4)}
+	mux.SetSdkChannel(NewSingleSdkChannel(ch))
+
+	// a dial addressed to a conn id the mux has never heard of, which is what the
+	// router sends once the hosting listener has gone away
+	const goneConnId = uint32(42)
+	req.False(mux.HasConn(goneConnId), "test requires the conn to be absent")
+
+	dial := newMsg(ContentTypeDial, goneConnId, []byte("some-session-token"))
+	dial.PutUint32Header(ConnIdHeader, goneConnId)
+
+	// a distinctive sequence, since an uncorrelated reply reports the unset default of -1 and
+	// would otherwise satisfy a correlation check against a freshly built message
+	const dialSeq = int32(1234)
+	dial.SetSequence(dialSeq)
+
+	mux.HandleReceive(dial, ch)
+
+	select {
+	case reply := <-ch.sent:
+		req.Equal(ContentTypeDialFailed, reply.ContentType,
+			"a dial for an unknown conn should be refused, not accepted")
+		req.True(reply.IsReplyingTo(dialSeq),
+			"the refusal must be correlated to the dial; the router keys its route-timeout wait on "+
+				"replyFor, so an uncorrelated reply leaves it waiting exactly as silence would")
+		connId, ok := reply.GetUint32Header(ConnIdHeader)
+		req.True(ok, "the refusal must carry a conn id")
+		req.Equal(goneConnId, connId, "the refusal must name the conn that was dialed")
+	case <-time.After(2 * time.Second):
+		req.Fail("no reply sent for a dial addressed to an unknown conn id; " +
+			"the router will wait out its route timeout and the dialing client will see a connect timeout")
+	}
+}

--- a/ziti/edge/msg_mux.go
+++ b/ziti/edge/msg_mux.go
@@ -387,9 +387,35 @@ func (mux *ConnMuxImpl[T]) HandleReceive(msg *channel.Message, ch channel.Channe
 		mux.handlePayloadWithNoSink(msg, ch)
 	} else if msg.ContentType == ContentTypeStateClosed {
 		// ignore, as conn is already closed
+	} else if msg.ContentType == ContentTypeDial {
+		go mux.handleDialWithNoSink(connId, msg, ch)
 	} else {
 		pfxlog.Logger().WithField("connId", connId).WithField("contentType", msg.ContentType).
 			Info("unable to dispatch msg received for unknown edge conn id")
+	}
+}
+
+// handleDialWithNoSink refuses a dial addressed to a conn this mux does not have.
+//
+// The router keeps forwarding dials for a hosted conn until its terminator is removed,
+// which happens after the conn is gone from here, so this arrives whenever a listener
+// closes while dials are in flight. The router waits for a reply under a route timeout
+// longer than the dialing client's connect timeout, so dropping it silently costs the
+// client its whole timeout; refusing it lets the router fail over to another terminator.
+func (mux *ConnMuxImpl[T]) handleDialWithNoSink(connId uint32, msg *channel.Message, ch channel.Channel) {
+	pfxlog.Logger().WithField("connId", int(connId)).
+		Info("refusing dial for unknown edge conn id")
+
+	var sender channel.Sender = ch
+	if sdkChan, ok := ch.GetSenders().(SdkChannel); ok {
+		sender = sdkChan.GetControlSender()
+	}
+
+	reply := NewDialFailedMsg(connId, fmt.Sprintf("no listener for conn id [%v]", connId))
+	reply.ReplyTo(msg)
+	if err := reply.WithTimeout(5 * time.Second).Send(sender); err != nil {
+		pfxlog.Logger().WithFields(GetLoggerFields(msg)).WithError(err).
+			Error("failed to refuse dial for unknown edge conn id")
 	}
 }
 


### PR DESCRIPTION
Fixes #999

When a dial arrives for an edge conn id the mux has no sink for, it was logged at info and dropped. The router then waited for a reply that never came. Since the router's route timeout (10s) outlasts the dialing client's connect timeout (5s), the client always lost the race and reported `context deadline exceeded`, and the controller never learned the terminator was unusable, so it could not fail over.

These dials are expected, not exceptional. Closing a hosted listener removes the conn from the mux before the unbind reaches the router, so any dial in flight during that gap lands with no sink. Closing is a statement that the SDK is done accepting, so the right behavior inside the gap is to refuse quickly rather than attempt to service the request. This replies `DialFailed`, which lets the router fail over to another terminator immediately.

Every other unroutable content type already had a handler: `ConnInspectRequest` is answered, `XgPayload` acks a circuit end, `StateClosed` is deliberately ignored. Dial was the gap.

Found via a flaky `Test_HSRotatingDataflow` in openziti/ziti, which rotates hosting listeners while dialing continuously. Outside tests it means a client dialing a service whose host is restarting can eat a full connect timeout instead of failing over.

The added test delivers a dial for an absent conn id and requires a reply within 2s. It fails on the previous behavior.