### PR TITLE
[Backport-1.8] Refuse dials for unknown edge conn ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Release notes 1.8.2
+
+## Issues Fixed and Dependency Updates
+
+* github.com/openziti/sdk-golang: [v1.8.1 -> v1.8.2](https://github.com/openziti/sdk-golang/compare/v1.8.1...v1.8.2)
+    * [Issue #1007](https://github.com/openziti/sdk-golang/issues/1007) - [Backport-1.8] Dial for an unknown edge conn id is dropped silently, costing the client its full connect timeout
+
+
 # Release notes 1.8.1
 
 ## Issues Fixed and Dependency Updates

--- a/ziti/edge/dial_no_sink_test.go
+++ b/ziti/edge/dial_no_sink_test.go
@@ -1,0 +1,97 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openziti/channel/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// replyCapturingChannel records what the SDK sends back to the router.
+//
+// It embeds channel.Channel rather than channel.MultiChannel deliberately: the refusal path
+// looks for a control sender by asserting MultiChannel, and failing that assertion is what
+// makes it fall back to sending on the channel itself, where Send records the message.
+type replyCapturingChannel struct {
+	channel.Channel
+	sent chan *channel.Message
+}
+
+func (ch *replyCapturingChannel) Send(s channel.Sendable) error {
+	// Sendable is an envelope wrapper once a timeout is attached, so take the message
+	// off it rather than type-asserting to *channel.Message.
+	select {
+	case ch.sent <- s.Msg():
+	default:
+	}
+	return nil
+}
+
+func (ch *replyCapturingChannel) TrySend(s channel.Sendable) (bool, error) {
+	return true, ch.Send(s)
+}
+
+func (ch *replyCapturingChannel) IsClosed() bool { return false }
+func (ch *replyCapturingChannel) Label() string  { return "test" }
+
+// Test_DialForUnknownConnIsAnswered pins the contract the router depends on: a dial
+// for a conn the SDK no longer hosts must be answered, not dropped.
+//
+// A hosted listener can close while its terminator is still selectable at the
+// controller, so the router will forward dials for it. The router waits for a reply
+// with a route timeout longer than the dialing client's connect timeout, so silence
+// here surfaces to the client as a connect timeout rather than a fast, retriable
+// failure.
+func Test_DialForUnknownConnIsAnswered(t *testing.T) {
+	req := require.New(t)
+
+	mux := NewChannelConnMapMux[any](nil)
+	ch := &replyCapturingChannel{sent: make(chan *channel.Message, 4)}
+
+	// a dial addressed to a conn id the mux has never heard of, which is what the
+	// router sends once the hosting listener has gone away
+	const goneConnId = uint32(42)
+	req.False(mux.HasConn(goneConnId), "test requires the conn to be absent")
+
+	dial := newMsg(ContentTypeDial, goneConnId, []byte("some-session-token"))
+	dial.PutUint32Header(ConnIdHeader, goneConnId)
+
+	// a distinctive sequence, since an uncorrelated reply reports the unset default of -1 and
+	// would otherwise satisfy a correlation check against a freshly built message
+	const dialSeq = int32(1234)
+	dial.SetSequence(dialSeq)
+
+	mux.HandleReceive(dial, ch)
+
+	select {
+	case reply := <-ch.sent:
+		req.Equal(ContentTypeDialFailed, reply.ContentType,
+			"a dial for an unknown conn should be refused, not accepted")
+		req.True(reply.IsReplyingTo(dialSeq),
+			"the refusal must be correlated to the dial; the router keys its route-timeout wait on "+
+				"replyFor, so an uncorrelated reply leaves it waiting exactly as silence would")
+		connId, ok := reply.GetUint32Header(ConnIdHeader)
+		req.True(ok, "the refusal must carry a conn id")
+		req.Equal(goneConnId, connId, "the refusal must name the conn that was dialed")
+	case <-time.After(2 * time.Second):
+		req.Fail("no reply sent for a dial addressed to an unknown conn id; " +
+			"the router will wait out its route timeout and the dialing client will see a connect timeout")
+	}
+}

--- a/ziti/edge/msg_mux.go
+++ b/ziti/edge/msg_mux.go
@@ -374,9 +374,37 @@ func (mux *ConnMuxImpl[T]) HandleReceive(msg *channel.Message, ch channel.Channe
 		mux.handlePayloadWithNoSink(msg, ch)
 	} else if msg.ContentType == ContentTypeStateClosed {
 		// ignore, as conn is already closed
+	} else if msg.ContentType == ContentTypeDial {
+		go mux.handleDialWithNoSink(connId, msg, ch)
 	} else {
 		pfxlog.Logger().WithField("connId", connId).WithField("contentType", msg.ContentType).
 			Info("unable to dispatch msg received for unknown edge conn id")
+	}
+}
+
+// handleDialWithNoSink refuses a dial addressed to a conn this mux does not have.
+//
+// The router keeps forwarding dials for a hosted conn until its terminator is removed,
+// which happens after the conn is gone from here, so this arrives whenever a listener
+// closes while dials are in flight. The router waits for a reply under a route timeout
+// longer than the dialing client's connect timeout, so dropping it silently costs the
+// client its whole timeout; refusing it lets the router fail over to another terminator.
+func (mux *ConnMuxImpl[T]) handleDialWithNoSink(connId uint32, msg *channel.Message, ch channel.Channel) {
+	pfxlog.Logger().WithField("connId", int(connId)).
+		Info("refusing dial for unknown edge conn id")
+
+	var sender channel.Sender = ch
+	if mc, ok := ch.(channel.MultiChannel); ok {
+		if sdkChan, ok := mc.GetUnderlayHandler().(SdkChannel); ok {
+			sender = sdkChan.GetControlSender()
+		}
+	}
+
+	reply := NewDialFailedMsg(connId, fmt.Sprintf("no listener for conn id [%v]", connId))
+	reply.ReplyTo(msg)
+	if err := reply.WithPriority(channel.Highest).WithTimeout(5 * time.Second).Send(sender); err != nil {
+		pfxlog.Logger().WithFields(GetLoggerFields(msg)).WithError(err).
+			Error("failed to refuse dial for unknown edge conn id")
 	}
 }
 

--- a/ziti/sdkinfo/build_info.go
+++ b/ziti/sdkinfo/build_info.go
@@ -20,5 +20,5 @@
 package sdkinfo
 
 const (
-	Version   = "v1.8.1"
+	Version   = "v1.8.2"
 )


### PR DESCRIPTION
Fixes #1007. Backport of #1000 to `release-v1.8.x`.

`ConnMuxImpl.HandleReceive` logged and dropped a dial addressed to a conn id it has no sink for. A hosted
listener can close while its terminator is still selectable at the controller, so the router forwards dials
for it whenever a listener closes with dials in flight. The router then waits for a reply under a route
timeout longer than the dialing client's connect timeout, so the silence reached the client as a connect
timeout instead of a fast, retriable failure. It now replies `DialFailed`, so the router can fail over to
another terminator.

### Ported rather than cherry-picked

`main` is `sdk-golang/v2` on `channel/v5`; this line is on `channel/v4`, so one call needed translating.
The surrounding code is otherwise unchanged here and the patch applied cleanly.

| v5 (`main`) | v4 (this branch) |
|---|---|
| `ch.GetSenders().(SdkChannel)` | `ch.(channel.MultiChannel)` then `GetUnderlayHandler().(SdkChannel)` |

That is not a new idiom: `returnInspectResponse` in this same file already reaches the control sender
exactly that way. The test's channel double drops its `GetSenders` method and the `SetSdkChannel` call for
the same reason. Neither exists on v4, and neither is needed: the double only has to not satisfy
`channel.MultiChannel` for the refusal to fall back to sending on the channel itself, which is where the
test captures it. Nothing else differs from the original commit.

### Why this line

`openziti/ziti` `release-v2.0.x` is pinned to the v1 line and is on `channel/v4`. It cannot take the fix
from `main`, and v1.9.0 also moved to `channel/v5`, so `release-v1.8.x` is the newest v1 line that can
carry it. It surfaces there as a CI flake in `Test_HSRotatingDataflow`, which rotates hosted listeners and
so reproduces the close-with-dials-in-flight window directly.

### Verification

Build and vet clean, full suite passes. The new test was checked against its own regression: with the
`ContentTypeDial` branch removed it fails with "no reply sent for a dial addressed to an unknown conn id",
and passes with it.
